### PR TITLE
Attr default

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -496,7 +496,7 @@ class Oven():
                     att_def = ''
                     if len(att_args) > 1:
                         att_def = self.eval_string_value(element,
-                                                         att_args[1][0])
+                                                         att_args[1])[0]
                     strval += element.etree_element.get(att_name, att_def)
 
                 elif term.name == u'uuid':
@@ -606,7 +606,7 @@ class Oven():
                         att_def = ''
                         if len(att_args) > 1:
                             att_def = self.eval_string_value(element,
-                                                             att_args[1][0])
+                                                             att_args[1])[0]
                         strval += element.etree_element.get(att_name, att_def)
                     else:
                         logger.warning("Bad string-set: {}".format(args))
@@ -856,7 +856,7 @@ class Oven():
                     att_def = ''
                     if len(att_args) > 1:
                         att_def = self.eval_string_value(element,
-                                                         att_args[1][0])
+                                                         att_args[1])[0]
                     att_val = element.etree_element.get(att_name, att_def)
                     actions.append(('string', att_val))
 

--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -475,17 +475,29 @@ class Oven():
 
             elif type(term) is ast.FunctionBlock:
                 if term.name == 'string':
-                    strname = serialize(term.arguments)
-                    val = self.lookup('strings', strname)
+                    str_args = split(term.arguments, ',')
+                    str_name = self.eval_string_value(element,
+                                                      str_args[0])[0]
+                    str_def = ''
+                    if len(str_args) > 1:
+                        str_def = self.eval_string_value(element,
+                                                         str_args[1])[0]
+                    val = self.lookup('strings', str_name)
                     if val == '':
                         logger.warning("{} blank string".
-                                       format(strname))
-                        continue
+                                       format(str_name))
+                        val = str_def
                     strval += val
 
                 elif term.name == u'attr':
-                    att_name = serialize(term.arguments)
-                    strval += element.etree_element.get(att_name, '')
+                    att_args = [serialize(t).strip(" \'")
+                                for t in split(term.arguments, ',')]
+                    att_name = att_args[0]
+                    att_def = ''
+                    if len(att_args) > 1:
+                        att_def = self.eval_string_value(element,
+                                                         att_args[1])
+                    strval += element.etree_element.get(att_name, att_def)
 
                 elif term.name == u'uuid':
                     strval += str(uuid4())
@@ -500,12 +512,14 @@ class Oven():
                     if strval:
                         vals.append(strval)
                         strval = ''
-                    delayed = [serialize(a).strip('" \'')
-                               for a in split(term.arguments, ',')]
+                    target_args = split(term.arguments, ',')
+                    vref = self.eval_string_value(element,
+                                                  target_args[0])[0]
+                    vname = self.eval_string_value(element,
+                                                   target_args[1])[0]
+
                     vtype = term.name[7:]+'s'
-                    delayed.insert(0, self)
-                    delayed.append(vtype)
-                    vals.append(TargetVal(*delayed))
+                    vals.append(TargetVal(self, vref[1:], vname, vtype))
 
                 elif term.name == u'first-letter':
                     tmpstr = self.eval_string_value(element, term.arguments)
@@ -560,12 +574,19 @@ class Oven():
 
             elif type(term) is ast.FunctionBlock:
                 if term.name == 'string':
-                    other_strname = serialize(term.arguments)
-                    val = self.lookup('strings', other_strname)
+                    str_args = split(term.arguments, ',')
+                    str_name = self.eval_string_value(element,
+                                                      str_args[0])[0]
+                    str_def = ''
+                    if len(str_args) > 1:
+                        str_def = self.eval_string_value(element,
+                                                         str_args[1])[0]
+                    val = self.lookup('strings', str_name)
                     if val == '':
                         logger.warning("{} blank string".
-                                       format(strname))
-                        continue
+                                       format(str_name))
+                        val = str_def
+
                     if strname is not None:
                         strval += val
                     else:
@@ -579,8 +600,14 @@ class Oven():
 
                 elif term.name == u'attr':
                     if strname is not None:
-                        att_name = serialize(term.arguments)
-                        strval += element.etree_element.get(att_name, '')
+                        att_args = [serialize(t).strip(" \'")
+                                    for t in split(term.arguments, ',')]
+                        att_name = att_args[0]
+                        att_def = ''
+                        if len(att_args) > 1:
+                            att_def = self.eval_string_value(element,
+                                                             att_args[1])
+                        strval += element.etree_element.get(att_name, att_def)
                     else:
                         logger.warning("Bad string-set: {}".format(args))
 
@@ -790,13 +817,20 @@ class Oven():
 
             elif type(term) is ast.FunctionBlock:
                 if term.name == 'string':
-                    strname = serialize(term.arguments)
-                    val = self.lookup('strings', strname)
+                    str_args = split(term.arguments, ',')
+                    str_name = self.eval_string_value(element,
+                                                      str_args[0])[0]
+                    str_def = ''
+                    if len(str_args) > 1:
+                        str_def = self.eval_string_value(element,
+                                                         str_args[1])[0]
+                    val = self.lookup('strings', str_name)
                     if val == '':
                         logger.warning("{} blank string".
-                                       format(strname))
-                        continue
-                    actions.append(('string', val))
+                                       format(str_name))
+                        val = str_def
+                    if val != '':
+                        actions.append(('string', val))
 
                 elif term.name == 'counter':
                     counterargs = [serialize(t).strip(" \'")
@@ -805,17 +839,26 @@ class Oven():
                     actions.append(('string', (count,)))
 
                 elif term.name.startswith('target-'):
-                    delayed = [serialize(a).strip('" \'')
-                               for a in split(term.arguments, ',')]
+                    target_args = split(term.arguments, ',')
+                    vref = self.eval_string_value(element,
+                                                  target_args[0])[0]
+                    vname = self.eval_string_value(element,
+                                                   target_args[1])[0]
+
                     vtype = term.name[7:]+'s'
-                    delayed.insert(0, self)
-                    delayed.append(vtype)
-                    actions.append(('string', [TargetVal(*delayed)]))
+                    actions.append(('string', [TargetVal(self, vref[1:],
+                                                         vname, vtype)]))
 
                 elif term.name == u'attr':
-                    att_name = serialize(term.arguments)
-                    actions.append(('string',
-                                    element.etree_element.get(att_name, '')))
+                    att_args = [serialize(t).strip(" \'")
+                                for t in split(term.arguments, ',')]
+                    att_name = att_args[0]
+                    att_def = ''
+                    if len(att_args) > 1:
+                        att_def = self.eval_string_value(element,
+                                                         att_args[1])
+                    att_val = element.etree_element.get(att_name, att_def)
+                    actions.append(('string', att_val))
 
                 elif term.name == u'uuid':
                     actions.append(('string', str(uuid4())))

--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -490,13 +490,13 @@ class Oven():
                     strval += val
 
                 elif term.name == u'attr':
-                    att_args = [serialize(t).strip(" \'")
-                                for t in split(term.arguments, ',')]
-                    att_name = att_args[0]
+                    att_args = split(term.arguments, ',')
+                    att_name = self.eval_string_value(element,
+                                                      att_args[0])[0]
                     att_def = ''
                     if len(att_args) > 1:
                         att_def = self.eval_string_value(element,
-                                                         att_args[1])
+                                                         att_args[1][0])
                     strval += element.etree_element.get(att_name, att_def)
 
                 elif term.name == u'uuid':
@@ -600,13 +600,13 @@ class Oven():
 
                 elif term.name == u'attr':
                     if strname is not None:
-                        att_args = [serialize(t).strip(" \'")
-                                    for t in split(term.arguments, ',')]
-                        att_name = att_args[0]
+                        att_args = split(term.arguments, ',')
+                        att_name = self.eval_string_value(element,
+                                                          att_args[0])[0]
                         att_def = ''
                         if len(att_args) > 1:
                             att_def = self.eval_string_value(element,
-                                                             att_args[1])
+                                                             att_args[1][0])
                         strval += element.etree_element.get(att_name, att_def)
                     else:
                         logger.warning("Bad string-set: {}".format(args))
@@ -850,13 +850,13 @@ class Oven():
                                                          vname, vtype)]))
 
                 elif term.name == u'attr':
-                    att_args = [serialize(t).strip(" \'")
-                                for t in split(term.arguments, ',')]
-                    att_name = att_args[0]
+                    att_args = split(term.arguments, ',')
+                    att_name = self.eval_string_value(element,
+                                                      att_args[0])[0]
                     att_def = ''
                     if len(att_args) > 1:
                         att_def = self.eval_string_value(element,
-                                                         att_args[1])
+                                                         att_args[1][0])
                     att_val = element.etree_element.get(att_name, att_def)
                     actions.append(('string', att_val))
 

--- a/cnxeasybake/tests/html/content_function.log
+++ b/cnxeasybake/tests/html/content_function.log
@@ -1,31 +1,37 @@
 cnx-easybake DEBUG Passes: ['default']
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: content attr(data-type) ": " content()
+cnx-easybake DEBUG IdentToken as string: data-type
 cnx-easybake DEBUG Rule (4): li::after 
 cnx-easybake DEBUG     default: content nosuch()
 cnx-easybake WARNING Unknown function nosuch
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: content attr(data-type) ": " content()
+cnx-easybake DEBUG IdentToken as string: data-type
 cnx-easybake DEBUG Rule (4): li::after 
 cnx-easybake DEBUG     default: content nosuch()
 cnx-easybake WARNING Unknown function nosuch
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: content attr(data-type) ": " content()
+cnx-easybake DEBUG IdentToken as string: data-type
 cnx-easybake DEBUG Rule (4): li::after 
 cnx-easybake DEBUG     default: content nosuch()
 cnx-easybake WARNING Unknown function nosuch
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: content attr(data-type) ": " content()
+cnx-easybake DEBUG IdentToken as string: data-type
 cnx-easybake DEBUG Rule (4): li::after 
 cnx-easybake DEBUG     default: content nosuch()
 cnx-easybake WARNING Unknown function nosuch
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: content attr(data-type) ": " content()
+cnx-easybake DEBUG IdentToken as string: data-type
 cnx-easybake DEBUG Rule (4): li::after 
 cnx-easybake DEBUG     default: content nosuch()
 cnx-easybake WARNING Unknown function nosuch
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: content attr(data-type) ": " content()
+cnx-easybake DEBUG IdentToken as string: data-type
 cnx-easybake DEBUG Rule (4): li::after 
 cnx-easybake DEBUG     default: content nosuch()
 cnx-easybake WARNING Unknown function nosuch

--- a/cnxeasybake/tests/html/counter_styles.log
+++ b/cnxeasybake/tests/html/counter_styles.log
@@ -1,14 +1,18 @@
 cnx-easybake DEBUG Passes: ['0', '2']
 cnx-easybake DEBUG Rule (23): body::before 
 cnx-easybake DEBUG     0: content "Hint, the food is at item #" target-counter("burger", items)
+cnx-easybake DEBUG IdentToken as string: items
 cnx-easybake DEBUG     0: container p
 cnx-easybake DEBUG     0: move-to b1
 cnx-easybake DEBUG Rule (28): body::before 
 cnx-easybake DEBUG     0: content "And maybe at #" target-counter("fries", items)
+cnx-easybake DEBUG IdentToken as string: items
 cnx-easybake DEBUG     0: container p
 cnx-easybake DEBUG     0: move-to b2
 cnx-easybake DEBUG Rule (33): body::before 
 cnx-easybake DEBUG     0: content "And has a title:" target-string(mylist, lname)
+cnx-easybake DEBUG IdentToken as string: mylist
+cnx-easybake DEBUG IdentToken as string: lname
 cnx-easybake DEBUG     0: container p
 cnx-easybake DEBUG     0: move-to b3
 cnx-easybake DEBUG Rule (1): ul 
@@ -27,6 +31,8 @@ cnx-easybake DEBUG     0: counter-increment items
 cnx-easybake DEBUG Rule (19): li[data-type="food"] 
 cnx-easybake DEBUG     0: counter-increment my-food 500
 cnx-easybake DEBUG     0: class "food-" target-counter(burger, items)
+cnx-easybake DEBUG IdentToken as string: burger
+cnx-easybake DEBUG IdentToken as string: items
 cnx-easybake DEBUG Rule (8): li::before 
 cnx-easybake DEBUG     0: container span
 cnx-easybake DEBUG     0: content counter(items, decimal) "|" counter(items, lower-roman) "|" counter(items, upper-roman) "|" counter(items, lower-alpha) "|" counter(items, upper-alpha) "|" counter(items, decimal-leading-zero)
@@ -77,7 +83,10 @@ cnx-easybake WARNING Number out of range for roman (must be 1..4999)
 cnx-easybake WARNING Counter out of range for latin (must be 1...26)
 cnx-easybake WARNING Counter out of range for latin (must be 1...26)
 cnx-easybake DEBUG Recipe 0 length: 139
-cnx-easybake WARNING Bad ID target lookup fries
+cnx-easybake WARNING Bad ID target lookup urger
+cnx-easybake WARNING Bad ID target lookup ries
+cnx-easybake WARNING Bad ID target lookup ylist
+cnx-easybake WARNING Bad ID target lookup urger
 cnx-easybake DEBUG Rule (38): body 
 cnx-easybake DEBUG     2: content pending(b1) pending(b2) pending(b3) content()
 cnx-easybake DEBUG     2: pass 2

--- a/cnxeasybake/tests/html/counter_styles_cooked.html
+++ b/cnxeasybake/tests/html/counter_styles_cooked.html
@@ -2,10 +2,10 @@
   <head>
     <title>Counter tests</title>
   </head>
-  <body><p>Hint, the food is at item #2</p><p>And maybe at #0</p><p>And has a title:This is the food and light list</p>
+  <body><p>Hint, the food is at item #0</p><p>And maybe at #0</p><p>And has a title:</p>
     <ul id="mylist">
       <li data-type="light"><span>1|i|I|a|A|01</span>street</li>
-      <li data-type="food" id="burger" class="food-2"><span>2|ii|II|b|B|02</span>hamburger</li>
+      <li data-type="food" id="burger" class="food-0"><span>2|ii|II|b|B|02</span>hamburger</li>
       <li data-type="light"><span>3|iii|III|c|C|03</span>night</li>
       <li data-type="light"><span>4|iv|IV|d|D|04</span>flash</li>
       <li data-type="light"><span>5|v|V|e|E|05</span>LED</li>

--- a/cnxeasybake/tests/html/counters.log
+++ b/cnxeasybake/tests/html/counters.log
@@ -2,6 +2,7 @@ cnx-easybake DEBUG Passes: ['default']
 cnx-easybake DEBUG Rule (21): body::before 
 cnx-easybake DEBUG     default: content "Hint, the food is at item #" target-counter("#burger", items) " And maybe at #" target-counter("#" attr(foodid), items) "And has a title:" target-string("#mylist", lname)
 cnx-easybake DEBUG IdentToken as string: items
+cnx-easybake DEBUG IdentToken as string: foodid
 cnx-easybake DEBUG IdentToken as string: items
 cnx-easybake DEBUG IdentToken as string: lname
 cnx-easybake DEBUG Rule (1): ul 

--- a/cnxeasybake/tests/html/counters.log
+++ b/cnxeasybake/tests/html/counters.log
@@ -1,50 +1,61 @@
 cnx-easybake DEBUG Passes: ['default']
-cnx-easybake DEBUG Rule (20): body::before 
-cnx-easybake DEBUG     default: content "Hint, the food is at item #" target-counter("burger", items) " And maybe at #" target-counter("fries", items) "And has a title:" target-string(mylist, lname)
+cnx-easybake DEBUG Rule (21): body::before 
+cnx-easybake DEBUG     default: content "Hint, the food is at item #" target-counter("#burger", items) " And maybe at #" target-counter("#" attr(foodid), items) "And has a title:" target-string("#mylist", lname)
+cnx-easybake DEBUG IdentToken as string: items
+cnx-easybake DEBUG IdentToken as string: items
+cnx-easybake DEBUG IdentToken as string: lname
 cnx-easybake DEBUG Rule (1): ul 
 cnx-easybake DEBUG     default: counter-reset lights, cardassian-lights, my-lights -1
 cnx-easybake DEBUG     default: counter-reset my-food 0
 cnx-easybake DEBUG     default: string-set lname "This is the food and light list"
-cnx-easybake DEBUG Rule (6): li 
+cnx-easybake DEBUG     default: attr-title string(lname)
+cnx-easybake DEBUG IdentToken as string: lname
+cnx-easybake DEBUG Rule (7): li 
 cnx-easybake DEBUG     default: counter-increment items
-cnx-easybake DEBUG Rule (9): li[data-type="light"] 
+cnx-easybake DEBUG Rule (10): li[data-type="light"] 
 cnx-easybake DEBUG     default: counter-increment lights
 cnx-easybake DEBUG     default: counter-increment my-lights
-cnx-easybake DEBUG Rule (6): li 
+cnx-easybake DEBUG Rule (7): li 
 cnx-easybake DEBUG     default: counter-increment items
-cnx-easybake DEBUG Rule (16): li[data-type="food"] 
+cnx-easybake DEBUG Rule (17): li[data-type="food"] 
 cnx-easybake DEBUG     default: counter-increment my-food 500
-cnx-easybake DEBUG     default: class "food-" target-counter(burger, items)
-cnx-easybake DEBUG Rule (6): li 
+cnx-easybake DEBUG     default: class "food-" target-counter("#burger", items)
+cnx-easybake DEBUG IdentToken as string: items
+cnx-easybake DEBUG Rule (7): li 
 cnx-easybake DEBUG     default: counter-increment items
-cnx-easybake DEBUG Rule (9): li[data-type="light"] 
+cnx-easybake DEBUG Rule (10): li[data-type="light"] 
 cnx-easybake DEBUG     default: counter-increment lights
 cnx-easybake DEBUG     default: counter-increment my-lights
-cnx-easybake DEBUG Rule (13): li[data-type="light"]:not(:first-of-type) 
+cnx-easybake DEBUG Rule (14): li[data-type="light"]:not(:first-of-type) 
 cnx-easybake DEBUG     default: counter-increment cardassian-lights
-cnx-easybake DEBUG Rule (6): li 
+cnx-easybake DEBUG Rule (7): li 
 cnx-easybake DEBUG     default: counter-increment items
-cnx-easybake DEBUG Rule (9): li[data-type="light"] 
+cnx-easybake DEBUG Rule (10): li[data-type="light"] 
 cnx-easybake DEBUG     default: counter-increment lights
 cnx-easybake DEBUG     default: counter-increment my-lights
-cnx-easybake DEBUG Rule (13): li[data-type="light"]:not(:first-of-type) 
+cnx-easybake DEBUG Rule (14): li[data-type="light"]:not(:first-of-type) 
 cnx-easybake DEBUG     default: counter-increment cardassian-lights
-cnx-easybake DEBUG Rule (6): li 
+cnx-easybake DEBUG Rule (7): li 
 cnx-easybake DEBUG     default: counter-increment items
-cnx-easybake DEBUG Rule (9): li[data-type="light"] 
+cnx-easybake DEBUG Rule (17): li[data-type="food"] 
+cnx-easybake DEBUG     default: counter-increment my-food 500
+cnx-easybake DEBUG     default: class "food-" target-counter("#burger", items)
+cnx-easybake DEBUG IdentToken as string: items
+cnx-easybake DEBUG Rule (7): li 
+cnx-easybake DEBUG     default: counter-increment items
+cnx-easybake DEBUG Rule (10): li[data-type="light"] 
 cnx-easybake DEBUG     default: counter-increment lights
 cnx-easybake DEBUG     default: counter-increment my-lights
-cnx-easybake DEBUG Rule (13): li[data-type="light"]:not(:first-of-type) 
+cnx-easybake DEBUG Rule (14): li[data-type="light"]:not(:first-of-type) 
 cnx-easybake DEBUG     default: counter-increment cardassian-lights
-cnx-easybake DEBUG Rule (23): body::after 
+cnx-easybake DEBUG Rule (24): body::after 
 cnx-easybake DEBUG     default: content "There are " counter(cardassian-lights) " lights!"
-cnx-easybake DEBUG Rule (26): body::after 
+cnx-easybake DEBUG Rule (27): body::after 
 cnx-easybake DEBUG     default: content "There are " counter(lights) " lights!"
-cnx-easybake DEBUG Rule (29): body::after 
+cnx-easybake DEBUG Rule (30): body::after 
 cnx-easybake DEBUG     default: content "There are " counter(my-lights) " lights!"
-cnx-easybake DEBUG Rule (32): body::after 
+cnx-easybake DEBUG Rule (33): body::after 
 cnx-easybake DEBUG     default: content "There are " counter(my-food) " calories!"
-cnx-easybake DEBUG Rule (35): body::after 
+cnx-easybake DEBUG Rule (36): body::after 
 cnx-easybake DEBUG     default: content "There are " counter(my-food, upper-roman) " calories!, " counter(lights, upper-latin) ", " counter(cardassian-lights, lower-latin)
-cnx-easybake DEBUG Recipe default length: 44
-cnx-easybake WARNING Bad ID target lookup fries
+cnx-easybake DEBUG Recipe default length: 48

--- a/cnxeasybake/tests/html/counters_cooked.html
+++ b/cnxeasybake/tests/html/counters_cooked.html
@@ -2,13 +2,14 @@
   <head>
     <title>Counter tests</title>
   </head>
-  <body><div>Hint, the food is at item #2 And maybe at #0And has a title:This is the food and light list</div>
-    <ul id="mylist">
+  <body foodid="fries"><div>Hint, the food is at item #2 And maybe at #5And has a title:This is the food and light list</div>
+    <ul id="mylist" title="This is the food and light list">
       <li data-type="light">street</li>
       <li data-type="food" id="burger" class="food-2">hamburger</li>
       <li data-type="light">night</li>
       <li data-type="light">flash</li>
+      <li data-type="food" id="fries" class="food-2">french fries</li>
       <li data-type="light">LED</li>
     </ul>
-  <div>There are 3 lights!</div><div>There are 4 lights!</div><div>There are 3 lights!</div><div>There are 500 calories!</div><div>There are D calories!, D, c</div></body>
+  <div>There are 3 lights!</div><div>There are 4 lights!</div><div>There are 3 lights!</div><div>There are 1000 calories!</div><div>There are M calories!, D, c</div></body>
 </html>

--- a/cnxeasybake/tests/html/counters_raw.html
+++ b/cnxeasybake/tests/html/counters_raw.html
@@ -2,12 +2,13 @@
   <head>
     <title>Counter tests</title>
   </head>
-  <body>
+  <body foodid="fries">
     <ul id="mylist">
       <li data-type="light">street</li>
       <li data-type="food" id="burger">hamburger</li>
       <li data-type="light">night</li>
       <li data-type="light">flash</li>
+      <li data-type="food" id="fries">french fries</li>
       <li data-type="light">LED</li>
     </ul>
   </body>

--- a/cnxeasybake/tests/html/default.log
+++ b/cnxeasybake/tests/html/default.log
@@ -14,6 +14,9 @@ cnx-easybake DEBUG Rule (11): li::after
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
 cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Rule (14): li::after 
+cnx-easybake DEBUG     default: content attr(string(itemtype))
+cnx-easybake DEBUG IdentToken as string: itemtype
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
 cnx-easybake DEBUG IdentToken as string: data-type
@@ -29,6 +32,9 @@ cnx-easybake DEBUG Rule (11): li::after
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
 cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Rule (14): li::after 
+cnx-easybake DEBUG     default: content attr(string(itemtype))
+cnx-easybake DEBUG IdentToken as string: itemtype
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
 cnx-easybake DEBUG IdentToken as string: data-type
@@ -44,6 +50,9 @@ cnx-easybake DEBUG Rule (11): li::after
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
 cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Rule (14): li::after 
+cnx-easybake DEBUG     default: content attr(string(itemtype))
+cnx-easybake DEBUG IdentToken as string: itemtype
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
 cnx-easybake DEBUG IdentToken as string: data-type
@@ -59,6 +68,9 @@ cnx-easybake DEBUG Rule (11): li::after
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
 cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Rule (14): li::after 
+cnx-easybake DEBUG     default: content attr(string(itemtype))
+cnx-easybake DEBUG IdentToken as string: itemtype
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
 cnx-easybake DEBUG IdentToken as string: data-type
@@ -74,6 +86,9 @@ cnx-easybake DEBUG Rule (11): li::after
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
 cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Rule (14): li::after 
+cnx-easybake DEBUG     default: content attr(string(itemtype))
+cnx-easybake DEBUG IdentToken as string: itemtype
 cnx-easybake DEBUG Rule (1): li 
 cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
 cnx-easybake DEBUG IdentToken as string: data-type
@@ -89,4 +104,7 @@ cnx-easybake DEBUG Rule (11): li::after
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
 cnx-easybake WARNING itemother blank string
-cnx-easybake DEBUG Recipe default length: 90
+cnx-easybake DEBUG Rule (14): li::after 
+cnx-easybake DEBUG     default: content attr(string(itemtype))
+cnx-easybake DEBUG IdentToken as string: itemtype
+cnx-easybake DEBUG Recipe default length: 114

--- a/cnxeasybake/tests/html/default.log
+++ b/cnxeasybake/tests/html/default.log
@@ -1,0 +1,92 @@
+cnx-easybake DEBUG Passes: ['default']
+cnx-easybake DEBUG Rule (1): li 
+cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
+cnx-easybake DEBUG IdentToken as string: data-type
+cnx-easybake DEBUG     default: string-set itemclass attr(class, "item")
+cnx-easybake DEBUG IdentToken as string: class
+cnx-easybake DEBUG Rule (5): li::after 
+cnx-easybake DEBUG     default: content "The type here: " string(itemtype, "None!")
+cnx-easybake DEBUG IdentToken as string: itemtype
+cnx-easybake DEBUG Rule (8): li::after 
+cnx-easybake DEBUG     default: content "The class here: " string(itemclass, "None!")
+cnx-easybake DEBUG IdentToken as string: itemclass
+cnx-easybake DEBUG Rule (11): li::after 
+cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
+cnx-easybake DEBUG IdentToken as string: itemother
+cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Rule (1): li 
+cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
+cnx-easybake DEBUG IdentToken as string: data-type
+cnx-easybake DEBUG     default: string-set itemclass attr(class, "item")
+cnx-easybake DEBUG IdentToken as string: class
+cnx-easybake DEBUG Rule (5): li::after 
+cnx-easybake DEBUG     default: content "The type here: " string(itemtype, "None!")
+cnx-easybake DEBUG IdentToken as string: itemtype
+cnx-easybake DEBUG Rule (8): li::after 
+cnx-easybake DEBUG     default: content "The class here: " string(itemclass, "None!")
+cnx-easybake DEBUG IdentToken as string: itemclass
+cnx-easybake DEBUG Rule (11): li::after 
+cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
+cnx-easybake DEBUG IdentToken as string: itemother
+cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Rule (1): li 
+cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
+cnx-easybake DEBUG IdentToken as string: data-type
+cnx-easybake DEBUG     default: string-set itemclass attr(class, "item")
+cnx-easybake DEBUG IdentToken as string: class
+cnx-easybake DEBUG Rule (5): li::after 
+cnx-easybake DEBUG     default: content "The type here: " string(itemtype, "None!")
+cnx-easybake DEBUG IdentToken as string: itemtype
+cnx-easybake DEBUG Rule (8): li::after 
+cnx-easybake DEBUG     default: content "The class here: " string(itemclass, "None!")
+cnx-easybake DEBUG IdentToken as string: itemclass
+cnx-easybake DEBUG Rule (11): li::after 
+cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
+cnx-easybake DEBUG IdentToken as string: itemother
+cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Rule (1): li 
+cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
+cnx-easybake DEBUG IdentToken as string: data-type
+cnx-easybake DEBUG     default: string-set itemclass attr(class, "item")
+cnx-easybake DEBUG IdentToken as string: class
+cnx-easybake DEBUG Rule (5): li::after 
+cnx-easybake DEBUG     default: content "The type here: " string(itemtype, "None!")
+cnx-easybake DEBUG IdentToken as string: itemtype
+cnx-easybake DEBUG Rule (8): li::after 
+cnx-easybake DEBUG     default: content "The class here: " string(itemclass, "None!")
+cnx-easybake DEBUG IdentToken as string: itemclass
+cnx-easybake DEBUG Rule (11): li::after 
+cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
+cnx-easybake DEBUG IdentToken as string: itemother
+cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Rule (1): li 
+cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
+cnx-easybake DEBUG IdentToken as string: data-type
+cnx-easybake DEBUG     default: string-set itemclass attr(class, "item")
+cnx-easybake DEBUG IdentToken as string: class
+cnx-easybake DEBUG Rule (5): li::after 
+cnx-easybake DEBUG     default: content "The type here: " string(itemtype, "None!")
+cnx-easybake DEBUG IdentToken as string: itemtype
+cnx-easybake DEBUG Rule (8): li::after 
+cnx-easybake DEBUG     default: content "The class here: " string(itemclass, "None!")
+cnx-easybake DEBUG IdentToken as string: itemclass
+cnx-easybake DEBUG Rule (11): li::after 
+cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
+cnx-easybake DEBUG IdentToken as string: itemother
+cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Rule (1): li 
+cnx-easybake DEBUG     default: string-set itemtype attr(data-type, "item")
+cnx-easybake DEBUG IdentToken as string: data-type
+cnx-easybake DEBUG     default: string-set itemclass attr(class, "item")
+cnx-easybake DEBUG IdentToken as string: class
+cnx-easybake DEBUG Rule (5): li::after 
+cnx-easybake DEBUG     default: content "The type here: " string(itemtype, "None!")
+cnx-easybake DEBUG IdentToken as string: itemtype
+cnx-easybake DEBUG Rule (8): li::after 
+cnx-easybake DEBUG     default: content "The class here: " string(itemclass, "None!")
+cnx-easybake DEBUG IdentToken as string: itemclass
+cnx-easybake DEBUG Rule (11): li::after 
+cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
+cnx-easybake DEBUG IdentToken as string: itemother
+cnx-easybake WARNING itemother blank string
+cnx-easybake DEBUG Recipe default length: 90

--- a/cnxeasybake/tests/html/default_cooked.html
+++ b/cnxeasybake/tests/html/default_cooked.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <title>Counter tests</title>
+  </head>
+  <body foodid="fries">
+    <ul id="mylist">
+      <li data-type="light">street<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div></li>
+      <li data-type="food" id="burger">hamburger<div>The type here: food</div><div>The class here: item</div><div>The other here: None!</div></li>
+      <li data-type="light">night<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div></li>
+      <li data-type="light">flash<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div></li>
+      <li data-type="food" id="fries">french fries<div>The type here: food</div><div>The class here: item</div><div>The other here: None!</div></li>
+      <li data-type="light">LED<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div></li>
+    </ul>
+  </body>
+</html>

--- a/cnxeasybake/tests/html/default_cooked.html
+++ b/cnxeasybake/tests/html/default_cooked.html
@@ -4,12 +4,12 @@
   </head>
   <body foodid="fries">
     <ul id="mylist">
-      <li data-type="light">street<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div></li>
-      <li data-type="food" id="burger">hamburger<div>The type here: food</div><div>The class here: item</div><div>The other here: None!</div></li>
-      <li data-type="light">night<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div></li>
-      <li data-type="light">flash<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div></li>
-      <li data-type="food" id="fries">french fries<div>The type here: food</div><div>The class here: item</div><div>The other here: None!</div></li>
-      <li data-type="light">LED<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div></li>
+      <li data-type="light">street<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div><div></div></li>
+      <li data-type="data-food" id="burger" data-food="burger">hamburger<div>The type here: data-food</div><div>The class here: item</div><div>The other here: None!</div><div>burger</div></li>
+      <li data-type="light">night<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div><div></div></li>
+      <li data-type="light">flash<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div><div></div></li>
+      <li data-type="food" id="fries">french fries<div>The type here: food</div><div>The class here: item</div><div>The other here: None!</div><div></div></li>
+      <li data-type="light">LED<div>The type here: light</div><div>The class here: item</div><div>The other here: None!</div><div></div></li>
     </ul>
   </body>
 </html>

--- a/cnxeasybake/tests/html/default_raw.html
+++ b/cnxeasybake/tests/html/default_raw.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <title>Counter tests</title>
+  </head>
+  <body foodid="fries">
+    <ul id="mylist">
+      <li data-type="light">street</li>
+      <li data-type="food" id="burger">hamburger</li>
+      <li data-type="light">night</li>
+      <li data-type="light">flash</li>
+      <li data-type="food" id="fries">french fries</li>
+      <li data-type="light">LED</li>
+    </ul>
+  </body>
+</html>

--- a/cnxeasybake/tests/html/default_raw.html
+++ b/cnxeasybake/tests/html/default_raw.html
@@ -5,7 +5,7 @@
   <body foodid="fries">
     <ul id="mylist">
       <li data-type="light">street</li>
-      <li data-type="food" id="burger">hamburger</li>
+      <li data-type="data-food" id="burger" data-food="burger">hamburger</li>
       <li data-type="light">night</li>
       <li data-type="light">flash</li>
       <li data-type="food" id="fries">french fries</li>

--- a/cnxeasybake/tests/html/deferred.log
+++ b/cnxeasybake/tests/html/deferred.log
@@ -8,11 +8,15 @@ cnx-easybake DEBUG     default: container div
 cnx-easybake DEBUG     default: content "This is a very small page with a string on it"
 cnx-easybake DEBUG Rule (1): div[data-type="chapter"] section.practice-test 
 cnx-easybake DEBUG     default: string-set childclasses string(childclasses) " " attr(class)
+cnx-easybake DEBUG IdentToken as string: childclasses
 cnx-easybake WARNING childclasses blank string
 cnx-easybake DEBUG Rule (4): div[data-type="chapter"] section.key-equations 
 cnx-easybake DEBUG     default: string-set childclasses string(childclasses) " " attr(class)
+cnx-easybake DEBUG IdentToken as string: childclasses
 cnx-easybake DEBUG Rule (1): div[data-type="chapter"] section.practice-test 
 cnx-easybake DEBUG     default: string-set childclasses string(childclasses) " " attr(class)
+cnx-easybake DEBUG IdentToken as string: childclasses
 cnx-easybake DEBUG Rule (7): div[data-type="chapter"]::deferred 
 cnx-easybake DEBUG     default: class string(childclasses)
+cnx-easybake DEBUG IdentToken as string: childclasses
 cnx-easybake DEBUG Recipe default length: 9

--- a/cnxeasybake/tests/html/deferred.log
+++ b/cnxeasybake/tests/html/deferred.log
@@ -10,12 +10,15 @@ cnx-easybake DEBUG Rule (1): div[data-type="chapter"] section.practice-test
 cnx-easybake DEBUG     default: string-set childclasses string(childclasses) " " attr(class)
 cnx-easybake DEBUG IdentToken as string: childclasses
 cnx-easybake WARNING childclasses blank string
+cnx-easybake DEBUG IdentToken as string: class
 cnx-easybake DEBUG Rule (4): div[data-type="chapter"] section.key-equations 
 cnx-easybake DEBUG     default: string-set childclasses string(childclasses) " " attr(class)
 cnx-easybake DEBUG IdentToken as string: childclasses
+cnx-easybake DEBUG IdentToken as string: class
 cnx-easybake DEBUG Rule (1): div[data-type="chapter"] section.practice-test 
 cnx-easybake DEBUG     default: string-set childclasses string(childclasses) " " attr(class)
 cnx-easybake DEBUG IdentToken as string: childclasses
+cnx-easybake DEBUG IdentToken as string: class
 cnx-easybake DEBUG Rule (7): div[data-type="chapter"]::deferred 
 cnx-easybake DEBUG     default: class string(childclasses)
 cnx-easybake DEBUG IdentToken as string: childclasses

--- a/cnxeasybake/tests/html/group_by.log
+++ b/cnxeasybake/tests/html/group_by.log
@@ -20,6 +20,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -37,6 +38,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -54,6 +56,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -71,6 +74,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -88,6 +92,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -105,6 +110,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -122,6 +128,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)

--- a/cnxeasybake/tests/html/group_by.log
+++ b/cnxeasybake/tests/html/group_by.log
@@ -17,6 +17,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -33,6 +34,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -49,6 +51,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -65,6 +68,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -81,6 +85,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -97,6 +102,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -113,6 +119,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link

--- a/cnxeasybake/tests/html/group_by_attr.log
+++ b/cnxeasybake/tests/html/group_by_attr.log
@@ -7,13 +7,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -26,13 +29,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -45,13 +51,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -64,13 +73,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -83,13 +95,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -102,13 +117,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -121,13 +139,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)

--- a/cnxeasybake/tests/html/group_by_attr.log
+++ b/cnxeasybake/tests/html/group_by_attr.log
@@ -11,6 +11,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -29,6 +30,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -47,6 +49,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -65,6 +68,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -83,6 +87,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -101,6 +106,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -119,6 +125,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link

--- a/cnxeasybake/tests/html/group_by_nocase.log
+++ b/cnxeasybake/tests/html/group_by_nocase.log
@@ -20,6 +20,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -37,6 +38,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -54,6 +56,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -71,6 +74,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -88,6 +92,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -105,6 +110,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -122,6 +128,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)

--- a/cnxeasybake/tests/html/group_by_nocase.log
+++ b/cnxeasybake/tests/html/group_by_nocase.log
@@ -17,6 +17,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -33,6 +34,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -49,6 +51,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -65,6 +68,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -81,6 +85,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -97,6 +102,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -113,6 +119,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link

--- a/cnxeasybake/tests/html/group_by_nogroup.log
+++ b/cnxeasybake/tests/html/group_by_nogroup.log
@@ -20,6 +20,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -37,6 +38,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -54,6 +56,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -71,6 +74,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -88,6 +92,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -105,6 +110,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -122,6 +128,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)

--- a/cnxeasybake/tests/html/group_by_nogroup.log
+++ b/cnxeasybake/tests/html/group_by_nogroup.log
@@ -17,6 +17,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -33,6 +34,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -49,6 +51,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -65,6 +68,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -81,6 +85,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -97,6 +102,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -113,6 +119,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link

--- a/cnxeasybake/tests/html/index.log
+++ b/cnxeasybake/tests/html/index.log
@@ -12,6 +12,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -29,6 +30,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -46,6 +48,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -63,6 +66,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -80,6 +84,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -97,6 +102,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -114,6 +120,7 @@ cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (16): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)

--- a/cnxeasybake/tests/html/index.log
+++ b/cnxeasybake/tests/html/index.log
@@ -9,6 +9,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -25,6 +26,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -41,6 +43,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -57,6 +60,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -73,6 +77,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -89,6 +94,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -105,6 +111,7 @@ cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link

--- a/cnxeasybake/tests/html/match.log
+++ b/cnxeasybake/tests/html/match.log
@@ -29,6 +29,7 @@ cnx-easybake DEBUG     2: move-to gloss-term
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
 cnx-easybake DEBUG     2: move-to link
@@ -49,6 +50,7 @@ cnx-easybake DEBUG     2: move-to gloss-term
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
 cnx-easybake DEBUG     2: move-to link
@@ -69,6 +71,7 @@ cnx-easybake DEBUG     2: move-to gloss-term
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
 cnx-easybake DEBUG     2: move-to link
@@ -89,6 +92,7 @@ cnx-easybake DEBUG     2: move-to gloss-term
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
 cnx-easybake DEBUG     2: move-to link
@@ -109,6 +113,7 @@ cnx-easybake DEBUG     2: move-to gloss-term
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
 cnx-easybake DEBUG     2: move-to link
@@ -129,6 +134,7 @@ cnx-easybake DEBUG     2: move-to gloss-term
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
 cnx-easybake DEBUG     2: move-to link
@@ -149,6 +155,7 @@ cnx-easybake DEBUG     2: move-to gloss-term
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
 cnx-easybake DEBUG     2: move-to link
@@ -169,6 +176,7 @@ cnx-easybake DEBUG     2: move-to gloss-term
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
 cnx-easybake DEBUG     2: move-to link

--- a/cnxeasybake/tests/html/match.log
+++ b/cnxeasybake/tests/html/match.log
@@ -22,6 +22,7 @@ cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::afte
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content content()
 cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
 cnx-easybake DEBUG     2: container span
 cnx-easybake DEBUG     2: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
@@ -32,6 +33,7 @@ cnx-easybake DEBUG     2: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     2: move-to link
 cnx-easybake DEBUG Rule (25): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
@@ -43,6 +45,7 @@ cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::afte
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content content()
 cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
 cnx-easybake DEBUG     2: container span
 cnx-easybake DEBUG     2: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
@@ -53,6 +56,7 @@ cnx-easybake DEBUG     2: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     2: move-to link
 cnx-easybake DEBUG Rule (25): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
@@ -64,6 +68,7 @@ cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::afte
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content content()
 cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
 cnx-easybake DEBUG     2: container span
 cnx-easybake DEBUG     2: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
@@ -74,6 +79,7 @@ cnx-easybake DEBUG     2: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     2: move-to link
 cnx-easybake DEBUG Rule (25): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
@@ -85,6 +91,7 @@ cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::afte
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content content()
 cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
 cnx-easybake DEBUG     2: container span
 cnx-easybake DEBUG     2: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
@@ -95,6 +102,7 @@ cnx-easybake DEBUG     2: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     2: move-to link
 cnx-easybake DEBUG Rule (25): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
@@ -106,6 +114,7 @@ cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::afte
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content content()
 cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
 cnx-easybake DEBUG     2: container span
 cnx-easybake DEBUG     2: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
@@ -116,6 +125,7 @@ cnx-easybake DEBUG     2: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     2: move-to link
 cnx-easybake DEBUG Rule (25): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
@@ -127,6 +137,7 @@ cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::afte
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content content()
 cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
 cnx-easybake DEBUG     2: container span
 cnx-easybake DEBUG     2: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
@@ -137,6 +148,7 @@ cnx-easybake DEBUG     2: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     2: move-to link
 cnx-easybake DEBUG Rule (25): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
@@ -148,6 +160,7 @@ cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::afte
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content content()
 cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
 cnx-easybake DEBUG     2: container span
 cnx-easybake DEBUG     2: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
@@ -158,6 +171,7 @@ cnx-easybake DEBUG     2: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     2: move-to link
 cnx-easybake DEBUG Rule (25): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2
@@ -169,6 +183,7 @@ cnx-easybake DEBUG Rule (10): div[data-type="page"] span[data-type="term"]::afte
 cnx-easybake DEBUG     2: pass 2
 cnx-easybake DEBUG     2: content content()
 cnx-easybake DEBUG     2: attr-group-by attr(group-by)
+cnx-easybake DEBUG IdentToken as string: group-by
 cnx-easybake DEBUG     2: container span
 cnx-easybake DEBUG     2: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
@@ -179,6 +194,7 @@ cnx-easybake DEBUG     2: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     2: container a
 cnx-easybake DEBUG     2: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     2: move-to link
 cnx-easybake DEBUG Rule (25): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     2: pass 2

--- a/cnxeasybake/tests/html/sort_attr.log
+++ b/cnxeasybake/tests/html/sort_attr.log
@@ -7,13 +7,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -26,13 +29,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -45,13 +51,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -64,13 +73,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -83,13 +95,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -102,13 +117,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)
@@ -121,13 +139,16 @@ cnx-easybake DEBUG     default: container span
 cnx-easybake DEBUG     default: class glossary-term
 cnx-easybake DEBUG IdentToken as string: glossary-term
 cnx-easybake DEBUG     default: attr-sortkey attr(sortkey)
+cnx-easybake DEBUG IdentToken as string: sortkey
 cnx-easybake DEBUG     default: attr-id attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
 cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG     default: move-to link
 cnx-easybake DEBUG Rule (18): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content pending(gloss-term) pending(link)

--- a/cnxeasybake/tests/html/sort_attr.log
+++ b/cnxeasybake/tests/html/sort_attr.log
@@ -11,6 +11,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -29,6 +30,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -47,6 +49,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -65,6 +68,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -83,6 +87,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -101,6 +106,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link
@@ -119,6 +125,7 @@ cnx-easybake DEBUG     default: attr-id attr(id)
 cnx-easybake DEBUG     default: move-to gloss-term
 cnx-easybake DEBUG Rule (12): div[data-type="page"] span[data-type="term"]::after 
 cnx-easybake DEBUG     default: content string(section-title)
+cnx-easybake DEBUG IdentToken as string: section-title
 cnx-easybake DEBUG     default: container a
 cnx-easybake DEBUG     default: attr-href "#" attr(id)
 cnx-easybake DEBUG     default: move-to link

--- a/cnxeasybake/tests/html/string_before.log
+++ b/cnxeasybake/tests/html/string_before.log
@@ -4,19 +4,27 @@ cnx-easybake DEBUG     default: string-set astring "Here's a string"
 cnx-easybake DEBUG Rule (4): div::before 
 cnx-easybake DEBUG     default: string-set mystring "My Cool String"
 cnx-easybake DEBUG     default: content string(astring)
+cnx-easybake DEBUG IdentToken as string: astring
 cnx-easybake DEBUG     default: class content() pending(astring) string(nostring)
 cnx-easybake WARNING Bad string value: pending() not allowed.  content() pending(astring) string(nostring)
+cnx-easybake DEBUG IdentToken as string: nostring
 cnx-easybake WARNING nostring blank string
 cnx-easybake DEBUG Rule (9): div::after 
 cnx-easybake DEBUG     default: content string(mystring)
+cnx-easybake DEBUG IdentToken as string: mystring
 cnx-easybake DEBUG     default: class string(astring)
+cnx-easybake DEBUG IdentToken as string: astring
 cnx-easybake DEBUG Rule (4): div::before 
 cnx-easybake DEBUG     default: string-set mystring "My Cool String"
 cnx-easybake DEBUG     default: content string(astring)
+cnx-easybake DEBUG IdentToken as string: astring
 cnx-easybake DEBUG     default: class content() pending(astring) string(nostring)
 cnx-easybake WARNING Bad string value: pending() not allowed.  content() pending(astring) string(nostring)
+cnx-easybake DEBUG IdentToken as string: nostring
 cnx-easybake WARNING nostring blank string
 cnx-easybake DEBUG Rule (9): div::after 
 cnx-easybake DEBUG     default: content string(mystring)
+cnx-easybake DEBUG IdentToken as string: mystring
 cnx-easybake DEBUG     default: class string(astring)
+cnx-easybake DEBUG IdentToken as string: astring
 cnx-easybake DEBUG Recipe default length: 20

--- a/cnxeasybake/tests/html/string_set.log
+++ b/cnxeasybake/tests/html/string_set.log
@@ -4,13 +4,16 @@ cnx-easybake DEBUG     default: string-set section "My Section String", section2
 cnx-easybake DEBUG     default: counter-reset mycounter
 cnx-easybake DEBUG Rule (5): div[data-type="chapter"] div[data-type="page"] div[data-type="title"] 
 cnx-easybake DEBUG     default: string-set myid attr(id) " " string(section) string(no-such-string)
-cnx-easybake WARNING myid blank string
+cnx-easybake DEBUG IdentToken as string: section
+cnx-easybake DEBUG IdentToken as string: no-such-string
+cnx-easybake WARNING no-such-string blank string
 cnx-easybake DEBUG     default: string-set mytitle first-letter(content()) ": " content()
 cnx-easybake DEBUG Rule (9): div[data-type="chapter"] div[data-type="page"] dl.definition 
 cnx-easybake DEBUG     default: move-to eoc-key-terms
 cnx-easybake DEBUG     default: string-set "bad bad"
 cnx-easybake WARNING Bad string-set:  "bad bad"
 cnx-easybake DEBUG     default: string-set string(section)
+cnx-easybake DEBUG IdentToken as string: section
 cnx-easybake WARNING Bad string-set:  string(section)
 cnx-easybake DEBUG     default: string-set attr(id)
 cnx-easybake WARNING Bad string-set:  attr(id)
@@ -26,6 +29,7 @@ cnx-easybake DEBUG     default: move-to eoc-key-terms
 cnx-easybake DEBUG     default: string-set "bad bad"
 cnx-easybake WARNING Bad string-set:  "bad bad"
 cnx-easybake DEBUG     default: string-set string(section)
+cnx-easybake DEBUG IdentToken as string: section
 cnx-easybake WARNING Bad string-set:  string(section)
 cnx-easybake DEBUG     default: string-set attr(id)
 cnx-easybake WARNING Bad string-set:  attr(id)
@@ -41,6 +45,7 @@ cnx-easybake DEBUG     default: move-to eoc-key-terms
 cnx-easybake DEBUG     default: string-set "bad bad"
 cnx-easybake WARNING Bad string-set:  "bad bad"
 cnx-easybake DEBUG     default: string-set string(section)
+cnx-easybake DEBUG IdentToken as string: section
 cnx-easybake WARNING Bad string-set:  string(section)
 cnx-easybake DEBUG     default: string-set attr(id)
 cnx-easybake WARNING Bad string-set:  attr(id)
@@ -53,8 +58,10 @@ cnx-easybake WARNING Bad string-set:pending() not allowed.  mystring pending(eoc
 cnx-easybake DEBUG     default: string-set name counter(mycounter)
 cnx-easybake DEBUG Rule (19): div[data-type="chapter"] div[data-type="page"]::after 
 cnx-easybake DEBUG     default: content string(mytitle)
+cnx-easybake DEBUG IdentToken as string: mytitle
 cnx-easybake DEBUG Rule (22): div[data-type="chapter"] div[data-type="page"]::after 
 cnx-easybake DEBUG     default: content first-letter(string(mytitle))
+cnx-easybake DEBUG IdentToken as string: mytitle
 cnx-easybake DEBUG     default: class first-letter(mytitle)
 cnx-easybake DEBUG IdentToken as string: mytitle
 cnx-easybake DEBUG Rule (1): div[data-type="chapter"] div[data-type="page"] 
@@ -62,23 +69,32 @@ cnx-easybake DEBUG     default: string-set section "My Section String", section2
 cnx-easybake DEBUG     default: counter-reset mycounter
 cnx-easybake DEBUG Rule (5): div[data-type="chapter"] div[data-type="page"] div[data-type="title"] 
 cnx-easybake DEBUG     default: string-set myid attr(id) " " string(section) string(no-such-string)
-cnx-easybake WARNING myid blank string
+cnx-easybake DEBUG IdentToken as string: section
+cnx-easybake DEBUG IdentToken as string: no-such-string
+cnx-easybake WARNING no-such-string blank string
 cnx-easybake DEBUG     default: string-set mytitle first-letter(content()) ": " content()
 cnx-easybake DEBUG Rule (19): div[data-type="chapter"] div[data-type="page"]::after 
 cnx-easybake DEBUG     default: content string(mytitle)
+cnx-easybake DEBUG IdentToken as string: mytitle
 cnx-easybake DEBUG Rule (22): div[data-type="chapter"] div[data-type="page"]::after 
 cnx-easybake DEBUG     default: content first-letter(string(mytitle))
+cnx-easybake DEBUG IdentToken as string: mytitle
 cnx-easybake DEBUG     default: class first-letter(mytitle)
 cnx-easybake DEBUG IdentToken as string: mytitle
 cnx-easybake DEBUG Rule (26): div[data-type="chapter"]::after 
 cnx-easybake DEBUG     default: class "strings, and things"
 cnx-easybake DEBUG     default: content string(section) ":" string(section2) ":" string(myid) string(no-such-string)
+cnx-easybake DEBUG IdentToken as string: section
+cnx-easybake DEBUG IdentToken as string: section2
+cnx-easybake DEBUG IdentToken as string: myid
+cnx-easybake DEBUG IdentToken as string: no-such-string
 cnx-easybake WARNING no-such-string blank string
 cnx-easybake DEBUG     default: container h1
 cnx-easybake DEBUG Rule (31): div[data-type="chapter"]::after 
 cnx-easybake DEBUG     default: class eoc-key-terms
 cnx-easybake DEBUG IdentToken as string: eoc-key-terms
 cnx-easybake DEBUG     default: content pending(eoc-key-terms) "MyId: " string(myid) " " attr(data-type)
+cnx-easybake DEBUG IdentToken as string: myid
 cnx-easybake DEBUG     default: container section
 cnx-easybake DEBUG     default: sort-by dl > dt
 cnx-easybake DEBUG Recipe default length: 40

--- a/cnxeasybake/tests/html/string_set.log
+++ b/cnxeasybake/tests/html/string_set.log
@@ -1,9 +1,11 @@
 cnx-easybake DEBUG Passes: ['default']
 cnx-easybake DEBUG Rule (1): div[data-type="chapter"] div[data-type="page"] 
 cnx-easybake DEBUG     default: string-set section "My Section String", section2 "My Second Section String", mytype attr(data-type)
+cnx-easybake DEBUG IdentToken as string: data-type
 cnx-easybake DEBUG     default: counter-reset mycounter
 cnx-easybake DEBUG Rule (5): div[data-type="chapter"] div[data-type="page"] div[data-type="title"] 
 cnx-easybake DEBUG     default: string-set myid attr(id) " " string(section) string(no-such-string)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG IdentToken as string: section
 cnx-easybake DEBUG IdentToken as string: no-such-string
 cnx-easybake WARNING no-such-string blank string
@@ -66,9 +68,11 @@ cnx-easybake DEBUG     default: class first-letter(mytitle)
 cnx-easybake DEBUG IdentToken as string: mytitle
 cnx-easybake DEBUG Rule (1): div[data-type="chapter"] div[data-type="page"] 
 cnx-easybake DEBUG     default: string-set section "My Section String", section2 "My Second Section String", mytype attr(data-type)
+cnx-easybake DEBUG IdentToken as string: data-type
 cnx-easybake DEBUG     default: counter-reset mycounter
 cnx-easybake DEBUG Rule (5): div[data-type="chapter"] div[data-type="page"] div[data-type="title"] 
 cnx-easybake DEBUG     default: string-set myid attr(id) " " string(section) string(no-such-string)
+cnx-easybake DEBUG IdentToken as string: id
 cnx-easybake DEBUG IdentToken as string: section
 cnx-easybake DEBUG IdentToken as string: no-such-string
 cnx-easybake WARNING no-such-string blank string
@@ -95,6 +99,7 @@ cnx-easybake DEBUG     default: class eoc-key-terms
 cnx-easybake DEBUG IdentToken as string: eoc-key-terms
 cnx-easybake DEBUG     default: content pending(eoc-key-terms) "MyId: " string(myid) " " attr(data-type)
 cnx-easybake DEBUG IdentToken as string: myid
+cnx-easybake DEBUG IdentToken as string: data-type
 cnx-easybake DEBUG     default: container section
 cnx-easybake DEBUG     default: sort-by dl > dt
 cnx-easybake DEBUG Recipe default length: 40

--- a/cnxeasybake/tests/html/two_pass.log
+++ b/cnxeasybake/tests/html/two_pass.log
@@ -33,6 +33,7 @@ cnx-easybake DEBUG     default: content "Two passes, doubled!"
 cnx-easybake DEBUG Rule (12): body::after 
 cnx-easybake DEBUG     default: pass counter(mine)
 cnx-easybake DEBUG     default: content string(onestring)
+cnx-easybake DEBUG IdentToken as string: onestring
 cnx-easybake DEBUG Recipe default length: 24
 cnx-easybake DEBUG Rule (35): div[data-type="page"]::before, div[data-type="composite-page"]::before 
 cnx-easybake DEBUG     second: pass second
@@ -60,4 +61,5 @@ cnx-easybake DEBUG     second: content "Two passes, doubled!"
 cnx-easybake DEBUG Rule (8): body::after 
 cnx-easybake DEBUG     second: pass "second"
 cnx-easybake DEBUG     second: content string(onestring)
+cnx-easybake DEBUG IdentToken as string: onestring
 cnx-easybake DEBUG Recipe second length: 32

--- a/cnxeasybake/tests/html/uuid_cooked.html
+++ b/cnxeasybake/tests/html/uuid_cooked.html
@@ -12,7 +12,7 @@
         </div>
     <div data-type="page">
         </div>
-<div class="eoc-practice-test" data-type="composite-page" id="a321ce14-3b04-44ee-8fc2-7ec2e9e17906">8e3fda66-929b-4688-98c3-5d37895bfded <section class="practice-test">
+        <div class="eoc-practice-test" data-type="composite-page" id="a321ce14-3b04-44ee-8fc2-7ec2e9e17906">8e3fda66-929b-4688-98c3-5d37895bfded <section class="practice-test">
             <p>Hi, I'm a practice test section</p>
         </section>
         <section class="practice-test">

--- a/cnxeasybake/tests/rulesets/counters.css
+++ b/cnxeasybake/tests/rulesets/counters.css
@@ -2,6 +2,7 @@ ul {
   counter-reset: lights, cardassian-lights, my-lights -1;
   counter-reset: my-food 0;
   string-set: lname "This is the food and light list";
+  attr-title: string(lname);
 }
 li {
   counter-increment: items;
@@ -15,10 +16,10 @@ li[data-type='light']:not(:first-of-type) {
 }
 li[data-type='food'] {
   counter-increment: my-food 500;
-  class: "food-" target-counter(burger, items);
+  class: "food-" target-counter("#burger", items);
 }
 body::before {
-  content: "Hint, the food is at item #" target-counter("burger", items) " And maybe at #" target-counter("fries", items) "And has a title:" target-string(mylist, lname);
+  content: "Hint, the food is at item #" target-counter("#burger", items) " And maybe at #" target-counter("#" attr(foodid), items) "And has a title:" target-string("#mylist", lname);
 }
 body::after {
   content: "There are " counter(cardassian-lights) " lights!";

--- a/cnxeasybake/tests/rulesets/counters.less
+++ b/cnxeasybake/tests/rulesets/counters.less
@@ -3,6 +3,7 @@ ul {
   counter-reset: lights, cardassian-lights, my-lights -1;
   counter-reset: my-food 0;
   string-set: lname "This is the food and light list";
+  attr-title: string(lname);
   }
 
 li {
@@ -18,11 +19,11 @@ li[data-type='light'] {
 }
 li[data-type='food'] {
     counter-increment: my-food 500;
-    class: "food-" target-counter(burger, items);
+    class: "food-" target-counter("#burger", items);
 }
 
 body::before {
-    content: "Hint, the food is at item #" target-counter("burger", items)  " And maybe at #" target-counter("fries", items) "And has a title:" target-string(mylist, lname);
+    content: "Hint, the food is at item #" target-counter("#burger", items)  " And maybe at #" target-counter("#" attr(foodid), items) "And has a title:" target-string("#mylist", lname);
     }
 body::after {
     content: "There are " counter(cardassian-lights) " lights!"

--- a/cnxeasybake/tests/rulesets/default.css
+++ b/cnxeasybake/tests/rulesets/default.css
@@ -11,3 +11,6 @@ li::after {
 li::after {
   content: "The other here: " string(itemother, 'None!');
 }
+li::after {
+  content: attr(string(itemtype));
+}

--- a/cnxeasybake/tests/rulesets/default.css
+++ b/cnxeasybake/tests/rulesets/default.css
@@ -1,0 +1,13 @@
+li {
+  string-set: itemtype attr(data-type, 'item');
+  string-set: itemclass attr(class, 'item');
+}
+li::after {
+  content: "The type here: " string(itemtype, 'None!');
+}
+li::after {
+  content: "The class here: " string(itemclass, 'None!');
+}
+li::after {
+  content: "The other here: " string(itemother, 'None!');
+}

--- a/cnxeasybake/tests/rulesets/default.less
+++ b/cnxeasybake/tests/rulesets/default.less
@@ -1,17 +1,17 @@
 //Test setting defaults on attr() and string()
-
 li {
-    string-set: itemtype attr(data-type, 'item');
-    string-set: itemclass attr(class, 'item');
-
-    &::after {
-        content: "The type here: " string(itemtype,'None!')
-    }
-    &::after {
-        content: "The class here: " string(itemclass,'None!')
-    }
-    &::after {
-        content: "The other here: " string(itemother,'None!')
-    }
+  string-set: itemtype attr(data-type, 'item');
+  string-set: itemclass attr(class, 'item');
+  &::after {
+    content: "The type here: " string(itemtype, 'None!');
+  }
+  &::after {
+    content: "The class here: " string(itemclass, 'None!');
+  }
+  &::after {
+    content: "The other here: " string(itemother, 'None!');
+  }
+  &::after {
+    content: attr(string(itemtype));
+  }
 }
-

--- a/cnxeasybake/tests/rulesets/default.less
+++ b/cnxeasybake/tests/rulesets/default.less
@@ -1,0 +1,17 @@
+//Test setting defaults on attr() and string()
+
+li {
+    string-set: itemtype attr(data-type, 'item');
+    string-set: itemclass attr(class, 'item');
+
+    &::after {
+        content: "The type here: " string(itemtype,'None!')
+    }
+    &::after {
+        content: "The class here: " string(itemclass,'None!')
+    }
+    &::after {
+        content: "The other here: " string(itemother,'None!')
+    }
+}
+

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ tests_require = (
 
 setup(
     name='cnx-easybake',
-    version='0.6.1',
+    version='0.7.0',
     author='Connexions team',
     author_email='info@cnx.org',
     url="https://github.com/connexions/cnx-easybake",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ tests_require = (
 
 setup(
     name='cnx-easybake',
-    version='0.6.0',
+    version='0.6.1',
     author='Connexions team',
     author_email='info@cnx.org',
     url="https://github.com/connexions/cnx-easybake",


### PR DESCRIPTION
This adds optional second param (default) for attr() and string(), as well as making the first param (name of attr or string) computable.