### PR TITLE
fixup ids when nodes are copied by adding a unique suffix

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -171,11 +171,9 @@ class Oven():
 
     def bake(self, element, last_step=None):
         """Apply recipes to HTML tree. Will build recipes if needed."""
-        if last_step in self.state['steps']:
-            stepidx = self.state['steps'].index(last_step)
-            self.state['steps'] = self.state['steps'][:stepidx]
-        elif last_step is not None:
-            logger.warning('Bad pass name: {}'.format(last_step))
+        if last_step is not None:
+            self.state['steps'] = [s for s in self.state['steps']
+                                   if s < last_step]
         for step in self.state['steps']:
             self.state['current_step'] = step
             self.state['scope'].insert(0, step)
@@ -191,6 +189,7 @@ class Oven():
                 step, len(recipe['actions'])))
             target = None
             old_content = {}
+            node_counts = {}
             for action, value in recipe['actions']:
                 if action == 'target':
                     target = value
@@ -227,7 +226,13 @@ class Oven():
                     grouped_insert(target, value)
 
                 elif action == 'copy':
-                    mycopy = deepcopy(value)  # FIXME deal w/ ID values
+                    mycopy = copy_w_id_suffix(value)
+                    mycopy.tail = None
+                    grouped_insert(target, mycopy)
+                elif action == 'nodeset':
+                    node_counts[value] = node_counts.setdefault(value,0) + 1
+                    suffix = '_copy_{}'.format(node_counts[value])
+                    mycopy = copy_w_id_suffix(value, suffix)
                     mycopy.tail = None
                     grouped_insert(target, mycopy)
                 else:
@@ -717,9 +722,9 @@ class Oven():
         elem = self.current_target().tree
         _, valstep = self.lookup('pending', target)
         if not valstep:
-            step['pending'][target] = [('copy', elem)]
+            step['pending'][target] = [('nodeset', elem)]
         else:
-            self.state[valstep]['pending'][target] = [('copy', elem)]
+            self.state[valstep]['pending'][target] = [('nodeset', elem)]
 
     @log_decl_method
     def do_copy_to(self, element, decl, pseudo):
@@ -870,8 +875,7 @@ class Oven():
 
                 elif term.name == u'content':
                     if pseudo in ('before', 'after'):
-                        # FIXME deal w/ IDs
-                        mycopy = deepcopy(element.etree_element)
+                        mycopy = copy_w_id_suffix(element.etree_element)
                         actions.append(('content', mycopy))
                     elif pseudo == 'outside':
                         actions.append(('move', element.etree_element))
@@ -895,7 +899,7 @@ class Oven():
                         continue
                     for action in val:
                             if action[0] == 'move':
-                                actions.append(('copy', action[1]))
+                                actions.append(('nodeset', action[1]))
                             else:
                                 actions.append(action)
 
@@ -1223,3 +1227,11 @@ def _to_roman(num):
             result += numeral
             num -= integer
     return result
+
+
+def copy_w_id_suffix(elem, suffix="_copy"):
+    """Make a deep copy of the provided tree, altering ids"""
+    mycopy = deepcopy(elem)
+    for id_elem in mycopy.xpath('//*[@id]'):
+        id_elem.set('id', id_elem.get('id') + suffix)
+    return mycopy

--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -230,7 +230,7 @@ class Oven():
                     mycopy.tail = None
                     grouped_insert(target, mycopy)
                 elif action == 'nodeset':
-                    node_counts[value] = node_counts.setdefault(value,0) + 1
+                    node_counts[value] = node_counts.setdefault(value, 0) + 1
                     suffix = '_copy_{}'.format(node_counts[value])
                     mycopy = copy_w_id_suffix(value, suffix)
                     mycopy.tail = None
@@ -1230,7 +1230,7 @@ def _to_roman(num):
 
 
 def copy_w_id_suffix(elem, suffix="_copy"):
-    """Make a deep copy of the provided tree, altering ids"""
+    """Make a deep copy of the provided tree, altering ids."""
     mycopy = deepcopy(elem)
     for id_elem in mycopy.xpath('//*[@id]'):
         id_elem.set('id', id_elem.get('id') + suffix)

--- a/cnxeasybake/tests/html/group_by_attr_cooked.html
+++ b/cnxeasybake/tests/html/group_by_attr_cooked.html
@@ -44,5 +44,5 @@
         </section>
     </div>
 </div>
-<div class="glossary"><div class="group-by"><span class="group-label">a</span><div class="glossary-item"><span class="glossary-term" sortkey="a" id="idterm1">drinks</span><a href="#idterm1">Drinks and Hydration</a><a href="#idterm2">Drinks and Hydration</a><a href="#idterm3">Drinks and Hydration</a><a href="#idterm4">Drinks and Hydration</a><a href="#idterm5">Drinks and Hydration</a><a href="#idterm6">Drinks and Hydration</a><a href="#idterm7">Drinks and Hydration</a></div></div></div></body>
+<div class="glossary"><div class="group-by"><span class="group-label">a</span><div class="glossary-item"><span class="glossary-term" sortkey="a" id="idterm1_copy">drinks</span><a href="#idterm1">Drinks and Hydration</a><a href="#idterm2">Drinks and Hydration</a><a href="#idterm3">Drinks and Hydration</a><a href="#idterm4">Drinks and Hydration</a><a href="#idterm5">Drinks and Hydration</a><a href="#idterm6">Drinks and Hydration</a><a href="#idterm7">Drinks and Hydration</a></div></div></div></body>
 </html>

--- a/cnxeasybake/tests/html/move_to_pseudo_cooked.html
+++ b/cnxeasybake/tests/html/move_to_pseudo_cooked.html
@@ -24,10 +24,10 @@
             <p>Hi, I'm a practice test section, too</p>
         </section>
     </div>
-<div class="summaries"><div><div id="sec1" data-type="title">Section The First!</div><section data-type="summary">
+<div class="summaries"><div><div id="sec1_copy_1" data-type="title">Section The First!</div><section data-type="summary">
             <p>Hi, I'm a summary section, for the first</p>
         </section>
-        </div><div><div id="sec2" data-type="title">Section The Second!</div><section data-type="summary">
+        </div><div><div id="sec2_copy_1" data-type="title">Section The Second!</div><section data-type="summary">
             <p>Hi, I'm a summary section, too (or 2)</p>
         </section>
         </div></div><section class="eoc-key-terms"><dl class="definition">

--- a/cnxeasybake/tests/html/node_set.log
+++ b/cnxeasybake/tests/html/node_set.log
@@ -12,6 +12,8 @@ cnx-easybake DEBUG     default: move-to eoc-key-terms
 cnx-easybake DEBUG Rule (10): div[data-type="chapter"] > div[data-type="page"]::after 
 cnx-easybake DEBUG     default: content nodes(mytitle) pending(sec-summary)
 cnx-easybake DEBUG     default: move-to eoc-summaries
+cnx-easybake DEBUG Rule (14): div[data-type="chapter"] > div[data-type="page"]::after 
+cnx-easybake DEBUG     default: content "My title is: " nodes(mytitle)
 cnx-easybake DEBUG Rule (1): div[data-type="chapter"] > div[data-type="page"] > div[data-type="title"] 
 cnx-easybake DEBUG     default: node-set mytitle
 cnx-easybake DEBUG Rule (4): div[data-type="chapter"] > div[data-type="page"] > section[data-type="summary"] 
@@ -19,15 +21,17 @@ cnx-easybake DEBUG     default: move-to sec-summary
 cnx-easybake DEBUG Rule (10): div[data-type="chapter"] > div[data-type="page"]::after 
 cnx-easybake DEBUG     default: content nodes(mytitle) pending(sec-summary)
 cnx-easybake DEBUG     default: move-to eoc-summaries
-cnx-easybake DEBUG Rule (14): div[data-type="chapter"]::after 
+cnx-easybake DEBUG Rule (14): div[data-type="chapter"] > div[data-type="page"]::after 
+cnx-easybake DEBUG     default: content "My title is: " nodes(mytitle)
+cnx-easybake DEBUG Rule (17): div[data-type="chapter"]::after 
 cnx-easybake DEBUG     default: class summaries
 cnx-easybake DEBUG IdentToken as string: summaries
 cnx-easybake DEBUG     default: content pending(eoc-summaries)
 cnx-easybake DEBUG     default: container div
-cnx-easybake DEBUG Rule (19): div[data-type="chapter"]::after 
+cnx-easybake DEBUG Rule (22): div[data-type="chapter"]::after 
 cnx-easybake DEBUG     default: class eoc-key-terms
 cnx-easybake DEBUG IdentToken as string: eoc-key-terms
 cnx-easybake DEBUG     default: content pending(eoc-key-terms)
 cnx-easybake DEBUG     default: container section
 cnx-easybake DEBUG     default: sort-by dl > dt
-cnx-easybake DEBUG Recipe default length: 23
+cnx-easybake DEBUG Recipe default length: 33

--- a/cnxeasybake/tests/html/node_set_cooked.html
+++ b/cnxeasybake/tests/html/node_set_cooked.html
@@ -17,17 +17,17 @@
                 <p>Hi, I'm a key equation</p>
             </section>
         </section>
-    </div>
+    <div>My title is: <div id="sec1_copy_2" data-type="title">Section The First!</div></div></div>
     <div data-type="page">
     <div id="sec2" data-type="title">Section The Second!</div>
         <section class="practice-test">
             <p>Hi, I'm a practice test section, too</p>
         </section>
-    </div>
-<div class="summaries"><div><div id="sec1" data-type="title">Section The First!</div><section data-type="summary">
+    <div>My title is: <div id="sec2_copy_2" data-type="title">Section The Second!</div></div></div>
+<div class="summaries"><div><div id="sec1_copy_1" data-type="title">Section The First!</div><section data-type="summary">
             <p>Hi, I'm a summary section, for the first</p>
         </section>
-        </div><div><div id="sec2" data-type="title">Section The Second!</div><section data-type="summary">
+        </div><div><div id="sec2_copy_1" data-type="title">Section The Second!</div><section data-type="summary">
             <p>Hi, I'm a summary section, too (or 2)</p>
         </section>
         </div></div><section class="eoc-key-terms"><dl class="definition">

--- a/cnxeasybake/tests/rulesets/node_set.css
+++ b/cnxeasybake/tests/rulesets/node_set.css
@@ -11,6 +11,9 @@ div[data-type='chapter'] > div[data-type='page']::after {
   content: nodes(mytitle) pending(sec-summary);
   move-to: eoc-summaries;
 }
+div[data-type='chapter'] > div[data-type='page']::after {
+  content: "My title is: " nodes(mytitle);
+}
 div[data-type='chapter']::after {
   class: summaries;
   content: pending(eoc-summaries);

--- a/cnxeasybake/tests/rulesets/node_set.less
+++ b/cnxeasybake/tests/rulesets/node_set.less
@@ -11,8 +11,11 @@ div[data-type='chapter'] {
         move-to: eoc-key-terms;
       }
       &::after {
-      content: nodes(mytitle) pending(sec-summary);
-      move-to: eoc-summaries
+        content: nodes(mytitle) pending(sec-summary);
+        move-to: eoc-summaries
+      }
+      &::after {
+        content: "My title is: " nodes(mytitle);
       }
   }
 }

--- a/cnxeasybake/tests/test_oven.py
+++ b/cnxeasybake/tests/test_oven.py
@@ -27,7 +27,7 @@ CSS = 'div { copy-to: end-of-chapter;}'
 BAD_CSS = 'not a selector {}'
 
 CSS_TWO_STEP = '''div[data-type="copy-me"] { step: 1; copy-to: "end-of-chapter" }
-div[data-type="book"]::after { step: 1; content: pending("end-of-chapter")} 
+div[data-type="book"]::after { step: 1; content: pending("end-of-chapter")}
 div[data-type="book"]::after {step: 5; content: "Here is a later step" }
 '''
 
@@ -35,6 +35,7 @@ HTML_ONE_STEP = '<html><head><title>example</title></head>\n<body>\n  <div data-
 
 
 HTML_TWO_STEP = '<html><head><title>example</title></head>\n<body>\n  <div data-type="book">\n    <div data-type="copy-me">Here is something to copy</div>\n  <div><div data-type="copy-me">Here is something to copy</div></div><div>Here is a later step</div></div>\n</body></html>'
+
 
 class OvenCssTest(unittest.TestCase):
     """Oven Css test cases.

--- a/cnxeasybake/tests/update-log-less.sh
+++ b/cnxeasybake/tests/update-log-less.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-rulename=${1:-*}
+rulename=${*:-*}
 for r in rulesets/${rulename}.less
     do
         file=$(basename $r)


### PR DESCRIPTION
Primiarily fix up IDs when copying. A  suffix of '_copy' is the default. If using a nodeset to copy, a number is used as well, so '_#_copy'. Also, allow for stop-at-pass numbers that fall between passes.