### PR TITLE
There may not be a default pass. Handle it

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -164,13 +164,20 @@ class Oven():
 
         steps = sorted(self.matchers.keys())
         if len(steps) > 1:
-            steps.remove('default')
-            try:
-                steps.sort(key=int)
-                steps.insert(0, '0')
-                self.matchers['0'] = self.matchers.pop('default')
-            except ValueError:
-                steps.insert(0, 'default')
+            if 'default' in steps:
+                steps.remove('default')
+                try:
+                    steps.sort(key=int)
+                    steps.insert(0, '0')
+                    self.matchers['0'] = self.matchers.pop('default')
+                except ValueError:
+                    steps.insert(0, 'default')
+            else:
+                try:
+                    steps.sort(key=int)
+                except ValueError:
+                    pass  # already sorted alpha
+
         self.clear_state()
         self.state['steps'] = steps
         logger.debug('Passes: %s' % steps)

--- a/cnxeasybake/tests/html/two_pass.log
+++ b/cnxeasybake/tests/html/two_pass.log
@@ -1,35 +1,36 @@
-cnx-easybake DEBUG Passes: ['default', u'counter(mine)', u'second']
-cnx-easybake DEBUG Rule (1): body 
-cnx-easybake DEBUG     default: string-set onestring "This is a first-pass string"
-cnx-easybake DEBUG Rule (14): div[data-type="chapter"] section.practice-test 
-cnx-easybake DEBUG     default: move-to eoc-practice-test
-cnx-easybake DEBUG Rule (17): div[data-type="chapter"] section.key-equations 
-cnx-easybake DEBUG     default: move-to eoc-key-equations
-cnx-easybake DEBUG Rule (14): div[data-type="chapter"] section.practice-test 
-cnx-easybake DEBUG     default: move-to eoc-practice-test
-cnx-easybake DEBUG Rule (20): div[data-type="chapter"]::after 
-cnx-easybake DEBUG     default: class eoc-practice-test
-cnx-easybake DEBUG IdentToken as string: eoc-practice-test
-cnx-easybake DEBUG     default: data-type composite-page
-cnx-easybake DEBUG IdentToken as string: composite-page
-cnx-easybake DEBUG     default: container div
-cnx-easybake DEBUG     default: content pending(eoc-practice-test)
-cnx-easybake DEBUG Rule (26): div[data-type="chapter"]::after 
-cnx-easybake DEBUG     default: class eoc-key-equations
-cnx-easybake DEBUG IdentToken as string: eoc-key-equations
-cnx-easybake DEBUG     default: data-type composite-page
-cnx-easybake DEBUG IdentToken as string: composite-page
-cnx-easybake DEBUG     default: attr-my-type study-this
-cnx-easybake DEBUG IdentToken as string: study-this
-cnx-easybake DEBUG     default: container div
-cnx-easybake DEBUG     default: content pending(eoc-key-equations)
-cnx-easybake DEBUG Rule (4): :pass("default") body::after, :pass("second") body::after 
-cnx-easybake DEBUG     default: content "Two passes, doubled!"
-cnx-easybake DEBUG Recipe default length: 20
+cnx-easybake DEBUG Passes: [u'counter(mine)', u'first', u'second']
 cnx-easybake DEBUG Rule (11): :pass(counter(mine)) body::after 
 cnx-easybake DEBUG     counter(mine): content string(onestring)
 cnx-easybake DEBUG IdentToken as string: onestring
+cnx-easybake WARNING onestring blank string
 cnx-easybake DEBUG Recipe counter(mine) length: 4
+cnx-easybake DEBUG Rule (1): body:pass("first") 
+cnx-easybake DEBUG     first: string-set onestring "This is a first-pass string"
+cnx-easybake DEBUG Rule (14): :pass(first) div[data-type="chapter"] section.practice-test 
+cnx-easybake DEBUG     first: move-to eoc-practice-test
+cnx-easybake DEBUG Rule (17): :pass(first) div[data-type="chapter"] section.key-equations 
+cnx-easybake DEBUG     first: move-to eoc-key-equations
+cnx-easybake DEBUG Rule (14): :pass(first) div[data-type="chapter"] section.practice-test 
+cnx-easybake DEBUG     first: move-to eoc-practice-test
+cnx-easybake DEBUG Rule (20): :pass(first) div[data-type="chapter"]::after 
+cnx-easybake DEBUG     first: class eoc-practice-test
+cnx-easybake DEBUG IdentToken as string: eoc-practice-test
+cnx-easybake DEBUG     first: data-type composite-page
+cnx-easybake DEBUG IdentToken as string: composite-page
+cnx-easybake DEBUG     first: container div
+cnx-easybake DEBUG     first: content pending(eoc-practice-test)
+cnx-easybake DEBUG Rule (26): :pass(first) div[data-type="chapter"]::after 
+cnx-easybake DEBUG     first: class eoc-key-equations
+cnx-easybake DEBUG IdentToken as string: eoc-key-equations
+cnx-easybake DEBUG     first: data-type composite-page
+cnx-easybake DEBUG IdentToken as string: composite-page
+cnx-easybake DEBUG     first: attr-my-type study-this
+cnx-easybake DEBUG IdentToken as string: study-this
+cnx-easybake DEBUG     first: container div
+cnx-easybake DEBUG     first: content pending(eoc-key-equations)
+cnx-easybake DEBUG Rule (4): :pass("first") body::after, :pass("second") body::after 
+cnx-easybake DEBUG     first: content "Two passes, doubled!"
+cnx-easybake DEBUG Recipe first length: 20
 cnx-easybake DEBUG Rule (33): :pass("second") div[data-type="page"]::before, :pass("second") div[data-type="composite-page"]::before 
 cnx-easybake DEBUG     second: counter-increment page
 cnx-easybake DEBUG     second: container h1
@@ -50,7 +51,7 @@ cnx-easybake DEBUG     second: counter-increment page
 cnx-easybake DEBUG     second: container h1
 cnx-easybake DEBUG     second: content "Chapter " counter(page)
 cnx-easybake DEBUG     second: attr-id "myid" counter(page)
-cnx-easybake DEBUG Rule (4): :pass("default") body::after, :pass("second") body::after 
+cnx-easybake DEBUG Rule (4): :pass("first") body::after, :pass("second") body::after 
 cnx-easybake DEBUG     second: content "Two passes, doubled!"
 cnx-easybake DEBUG Rule (8): :pass("second") body::after 
 cnx-easybake DEBUG     second: content string(onestring)

--- a/cnxeasybake/tests/html/two_pass_cooked.html
+++ b/cnxeasybake/tests/html/two_pass_cooked.html
@@ -22,5 +22,5 @@
             <p>Hi, I'm a key equation</p>
         </section>
     </div></div>
-<div>Two passes, doubled!</div><div>This is a first-pass string</div><div>Two passes, doubled!</div><div>This is a first-pass string</div></body>
+<div>Two passes, doubled!</div><div>Two passes, doubled!</div><div>This is a first-pass string</div></body>
 </html>

--- a/cnxeasybake/tests/rulesets/two_pass.css
+++ b/cnxeasybake/tests/rulesets/two_pass.css
@@ -1,7 +1,7 @@
-body {
+body:pass('first') {
   string-set: onestring "This is a first-pass string";
 }
-:pass('default') body::after,
+:pass('first') body::after,
 :pass('second') body::after {
   content: "Two passes, doubled!";
 }
@@ -11,19 +11,19 @@ body {
 :pass(counter(mine)) body::after {
   content: string(onestring);
 }
-div[data-type='chapter'] section.practice-test {
+:pass(first) div[data-type='chapter'] section.practice-test {
   move-to: eoc-practice-test;
 }
-div[data-type='chapter'] section.key-equations {
+:pass(first) div[data-type='chapter'] section.key-equations {
   move-to: eoc-key-equations;
 }
-div[data-type='chapter']::after {
+:pass(first) div[data-type='chapter']::after {
   class: eoc-practice-test;
   data-type: composite-page;
   container: div;
   content: pending(eoc-practice-test);
 }
-div[data-type='chapter']::after {
+:pass(first) div[data-type='chapter']::after {
   class: eoc-key-equations;
   data-type: composite-page;
   attr-my-type: study-this;

--- a/cnxeasybake/tests/rulesets/two_pass.less
+++ b/cnxeasybake/tests/rulesets/two_pass.less
@@ -1,10 +1,11 @@
 // Test two pending buckets targeting same after
-body {
+body:pass('first') {
+
     string-set: onestring "This is a first-pass string";
 
 }
 
-:pass('default'), :pass('second') {
+:pass('first'), :pass('second') {
     body {
         &::after {
     	content: "Two passes, doubled!";
@@ -27,7 +28,7 @@ body {
     }
 }
 
-div[data-type='chapter'] {
+:pass(first) div[data-type='chapter'] {
     section.practice-test {
         move-to: eoc-practice-test;
     }


### PR DESCRIPTION
@tomjw64 found a missing corner case: if all passes are declared, and none of them match the string 'default', we error. Oops. Fixes that, and modifies two_pass test to cover that case.