### PR TITLE
when moving a node, leave the text tail behind

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -236,8 +236,16 @@ class Oven():
                     else:
                         append_string(target, strval)
                 elif action == 'move':
+                    if value.tail is not None:
+                        val_prev = value.getprevious()
+                        if val_prev is not None:
+                            val_prev.tail = value.tail
+                        else:
+                            val_parent = value.getparent()
+                            if val_parent is not None:
+                                val_parent.text = value.tail
+                    value.tail = None
                     grouped_insert(target, value)
-
                 elif action == 'copy':
                     mycopy = copy_w_id_suffix(value)
                     mycopy.tail = None

--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -236,15 +236,6 @@ class Oven():
                     else:
                         append_string(target, strval)
                 elif action == 'move':
-                    if value.tail is not None:
-                        val_prev = value.getprevious()
-                        if val_prev is not None:
-                            val_prev.tail = value.tail
-                        else:
-                            val_parent = value.getparent()
-                            if val_parent is not None:
-                                val_parent.text = value.tail
-                    value.tail = None
                     grouped_insert(target, value)
                 elif action == 'copy':
                     mycopy = copy_w_id_suffix(value)
@@ -1187,6 +1178,15 @@ def prepend_string(t, string):
 
 def grouped_insert(t, value):
     """Insert value into the target tree 't' with correct grouping."""
+    if value.tail is not None:
+        val_prev = value.getprevious()
+        if val_prev is not None:
+            val_prev.tail = (val_prev.tail or '') + value.tail
+        else:
+            val_parent = value.getparent()
+            if val_parent is not None:
+                val_parent.text = (val_parent.text or '') + value.tail
+    value.tail = None
     if t.isgroup and t.sort(value) is not None:
         if t.groupby:
             for child in t.tree:

--- a/cnxeasybake/tests/html/move_tails.log
+++ b/cnxeasybake/tests/html/move_tails.log
@@ -18,4 +18,42 @@ cnx-easybake DEBUG     default: move-to tableCaption
 cnx-easybake DEBUG Rule (18): table::after 
 cnx-easybake DEBUG     default: container caption
 cnx-easybake DEBUG     default: content pending(tableCaption)
-cnx-easybake DEBUG Recipe default length: 18
+cnx-easybake DEBUG Rule (1): table > caption 
+cnx-easybake DEBUG     default: container span
+cnx-easybake DEBUG     default: class caption
+cnx-easybake DEBUG IdentToken as string: caption
+cnx-easybake DEBUG     default: data-type "caption"
+cnx-easybake DEBUG     default: move-to tableCap
+cnx-easybake DEBUG Rule (7): table > caption [data-type="title"] 
+cnx-easybake DEBUG     default: container span
+cnx-easybake DEBUG     default: class caption
+cnx-easybake DEBUG IdentToken as string: caption
+cnx-easybake DEBUG     default: data-type "caption-title"
+cnx-easybake DEBUG     default: move-to tableTitle
+cnx-easybake DEBUG Rule (13): table > caption::after 
+cnx-easybake DEBUG     default: class "caption-container"
+cnx-easybake DEBUG     default: content pending(tableTitle) pending(tableCap)
+cnx-easybake DEBUG     default: move-to tableCaption
+cnx-easybake DEBUG Rule (18): table::after 
+cnx-easybake DEBUG     default: container caption
+cnx-easybake DEBUG     default: content pending(tableCaption)
+cnx-easybake DEBUG Rule (1): table > caption 
+cnx-easybake DEBUG     default: container span
+cnx-easybake DEBUG     default: class caption
+cnx-easybake DEBUG IdentToken as string: caption
+cnx-easybake DEBUG     default: data-type "caption"
+cnx-easybake DEBUG     default: move-to tableCap
+cnx-easybake DEBUG Rule (7): table > caption [data-type="title"] 
+cnx-easybake DEBUG     default: container span
+cnx-easybake DEBUG     default: class caption
+cnx-easybake DEBUG IdentToken as string: caption
+cnx-easybake DEBUG     default: data-type "caption-title"
+cnx-easybake DEBUG     default: move-to tableTitle
+cnx-easybake DEBUG Rule (13): table > caption::after 
+cnx-easybake DEBUG     default: class "caption-container"
+cnx-easybake DEBUG     default: content pending(tableTitle) pending(tableCap)
+cnx-easybake DEBUG     default: move-to tableCaption
+cnx-easybake DEBUG Rule (18): table::after 
+cnx-easybake DEBUG     default: container caption
+cnx-easybake DEBUG     default: content pending(tableCaption)
+cnx-easybake DEBUG Recipe default length: 54

--- a/cnxeasybake/tests/html/move_tails.log
+++ b/cnxeasybake/tests/html/move_tails.log
@@ -1,0 +1,21 @@
+cnx-easybake DEBUG Passes: ['default']
+cnx-easybake DEBUG Rule (1): table > caption 
+cnx-easybake DEBUG     default: container span
+cnx-easybake DEBUG     default: class caption
+cnx-easybake DEBUG IdentToken as string: caption
+cnx-easybake DEBUG     default: data-type "caption"
+cnx-easybake DEBUG     default: move-to tableCap
+cnx-easybake DEBUG Rule (7): table > caption [data-type="title"] 
+cnx-easybake DEBUG     default: container span
+cnx-easybake DEBUG     default: class caption
+cnx-easybake DEBUG IdentToken as string: caption
+cnx-easybake DEBUG     default: data-type "caption-title"
+cnx-easybake DEBUG     default: move-to tableTitle
+cnx-easybake DEBUG Rule (13): table > caption::after 
+cnx-easybake DEBUG     default: class "caption-container"
+cnx-easybake DEBUG     default: content pending(tableTitle) pending(tableCap)
+cnx-easybake DEBUG     default: move-to tableCaption
+cnx-easybake DEBUG Rule (18): table::after 
+cnx-easybake DEBUG     default: container caption
+cnx-easybake DEBUG     default: content pending(tableCaption)
+cnx-easybake DEBUG Recipe default length: 18

--- a/cnxeasybake/tests/html/move_tails_cooked.html
+++ b/cnxeasybake/tests/html/move_tails_cooked.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <title>Pass the tail</title>
+    </head><body>
+        <table><tr><td>one</td></tr><tr><td>two</td></tr>
+<caption><div class="caption-container"><span data-type="caption-title" class="caption">Economic Freedoms, 2015</span><span class="caption" data-type="caption">
+  (Source: The Heritage Foundation, 2015 Index of Economic Freedom, Country Rankings, http://www.heritage.org/index/ranking)
+</span></div></caption></table>
+    </body></html>

--- a/cnxeasybake/tests/html/move_tails_cooked.html
+++ b/cnxeasybake/tests/html/move_tails_cooked.html
@@ -3,7 +3,27 @@
         <title>Pass the tail</title>
     </head><body>
         <table><tr><td>one</td></tr><tr><td>two</td></tr>
+
+
 <caption><div class="caption-container"><span data-type="caption-title" class="caption">Economic Freedoms, 2015</span><span class="caption" data-type="caption">
+  
   (Source: The Heritage Foundation, 2015 Index of Economic Freedom, Country Rankings, http://www.heritage.org/index/ranking)
 </span></div></caption></table>
+
+<table><tr><td>test with text alreadty on parent node</td></tr>
+            
+<caption><div class="caption-container"><span data-type="caption-title" class="caption">My caption title</span><span class="caption" data-type="caption">
+                Some text here.
+            
+                More text here.
+            </span></div></caption></table>
+
+<table><tr><td>test with text alreadty on parent node</td></tr>
+            
+<caption><div class="caption-container"><span data-type="caption-title" class="caption">My caption title</span><span class="caption" data-type="caption">
+                Some <b>bold text</b> here.
+            
+                More text here.
+            </span></div></caption></table>
+
     </body></html>

--- a/cnxeasybake/tests/html/move_tails_raw.html
+++ b/cnxeasybake/tests/html/move_tails_raw.html
@@ -1,0 +1,12 @@
+<html>
+    <head>
+        <title>Pass the tail</title>
+    <body>
+        <table><tr><td>one</td></tr><tr><td>two</td></tr>
+
+<caption>
+  <span data-type="title">Economic Freedoms, 2015</span>
+  (Source: The Heritage Foundation, 2015 Index of Economic Freedom, Country Rankings, http://www.heritage.org/index/ranking)
+</caption>
+</table>
+    </body></html>

--- a/cnxeasybake/tests/html/move_tails_raw.html
+++ b/cnxeasybake/tests/html/move_tails_raw.html
@@ -9,4 +9,21 @@
   (Source: The Heritage Foundation, 2015 Index of Economic Freedom, Country Rankings, http://www.heritage.org/index/ranking)
 </caption>
 </table>
+
+<table><tr><td>test with text alreadty on parent node</td></tr>
+            <caption>
+                Some text here.
+            <span data-type="title">My caption title</span>
+                More text here.
+            </caption>
+</table>
+
+<table><tr><td>test with text alreadty on parent node</td></tr>
+            <caption>
+                Some <b>bold text</b> here.
+            <span data-type="title">My caption title</span>
+                More text here.
+            </caption>
+</table>
+
     </body></html>

--- a/cnxeasybake/tests/rulesets/move_tails.css
+++ b/cnxeasybake/tests/rulesets/move_tails.css
@@ -1,0 +1,21 @@
+table > caption {
+  container: span;
+  class: caption;
+  data-type: "caption";
+  move-to: tableCap;
+}
+table > caption [data-type="title"] {
+  container: span;
+  class: caption;
+  data-type: "caption-title";
+  move-to: tableTitle;
+}
+table > caption::after {
+  class: "caption-container";
+  content: pending(tableTitle) pending(tableCap);
+  move-to: tableCaption;
+}
+table::after {
+  container: caption;
+  content: pending(tableCaption);
+}

--- a/cnxeasybake/tests/rulesets/move_tails.less
+++ b/cnxeasybake/tests/rulesets/move_tails.less
@@ -1,0 +1,22 @@
+table > caption {
+        [data-type="title"] {
+          container: span;
+          class: caption;
+          data-type: "caption-title";
+          move-to: tableTitle;
+        }
+        container: span;
+        class: caption;
+        data-type: "caption";
+        move-to: tableCap;
+ &::after {
+        class: "caption-container";
+        content: pending(tableTitle) pending(tableCap);
+        move-to: tableCaption;
+      }
+    }
+
+table::after {
+        container: caption;
+        content: pending(tableCaption);
+      }


### PR DESCRIPTION
flowed text in an HTML, when parsed as a tree, distributes a nodes text values across it's own 'text' attribute, as well as the 'tail' attributes of all of its children. When moving such a child, make sure to leave the 'tail' behind, on either he previous sibling or the parent node. fixes issue #27