### PR TITLE
support CSS comments

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -277,8 +277,9 @@ class Oven():
                 logger.debug('Rule ({}): {}'.format(*rule))
                 self.push_target_elem(element)
                 for decl in declarations:
-                    method = self.find_method(decl.name)
-                    method(element, decl, None)
+                    if decl.type == 'declaration': # Could also be a 'comment'. Or could use `hasattr(decl, 'name')`
+                        method = self.find_method(decl.name)
+                        method(element, decl, None)
 
         # Store all variables (strings and counters) before children
         if element_id:

--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -277,7 +277,8 @@ class Oven():
                 logger.debug('Rule ({}): {}'.format(*rule))
                 self.push_target_elem(element)
                 for decl in declarations:
-                    if decl.type == 'declaration': # Could also be a 'comment'. Or could use `hasattr(decl, 'name')`
+                    # decl Could also be a 'comment'.
+                    if decl.type == 'declaration':
                         method = self.find_method(decl.name)
                         method(element, decl, None)
 

--- a/cnxeasybake/tests/html/css_comments.log
+++ b/cnxeasybake/tests/html/css_comments.log
@@ -1,0 +1,1 @@
+cnx-easybake DEBUG Passes: []

--- a/cnxeasybake/tests/html/css_comments_cooked.html
+++ b/cnxeasybake/tests/html/css_comments_cooked.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    Verifying that CSS comments will be ignored (not cause an exception)
+  </body>
+</html>

--- a/cnxeasybake/tests/html/css_comments_raw.html
+++ b/cnxeasybake/tests/html/css_comments_raw.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    Verifying that CSS comments will be ignored (not cause an exception)
+  </body>
+</html>

--- a/cnxeasybake/tests/rulesets/css_comments.css
+++ b/cnxeasybake/tests/rulesets/css_comments.css
@@ -1,0 +1,1 @@
+/* This ensures that comments in a CSS file do not cause an error */

--- a/cnxeasybake/tests/rulesets/css_comments.less
+++ b/cnxeasybake/tests/rulesets/css_comments.less
@@ -1,0 +1,3 @@
+// Ensure CSS Comments do not cause an Error
+/* This ensures that comments in a CSS file do not cause an error */
+body { }


### PR DESCRIPTION
Currently, the oven throws an error when parsing a CSS file with comments. This fixes the code so it just ignores comments