### PR TITLE
only warn about empty strings if no default provided

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -563,15 +563,14 @@ class Oven():
                     str_args = split(term.arguments, ',')
                     str_name = self.eval_string_value(element,
                                                       str_args[0])[0]
-                    str_def = ''
-                    if len(str_args) > 1:
-                        str_def = self.eval_string_value(element,
-                                                         str_args[1])[0]
                     val = self.lookup('strings', str_name)
                     if val == '':
-                        logger.warning("{} blank string".
-                                       format(str_name))
-                        val = str_def
+                        if len(str_args) > 1:
+                            val = self.eval_string_value(element,
+                                                         str_args[1])[0]
+                        else:
+                            logger.warning("{} blank string".
+                                           format(str_name))
                     strval += val
 
                 elif term.name == u'attr':
@@ -672,15 +671,14 @@ class Oven():
                     str_args = split(term.arguments, ',')
                     str_name = self.eval_string_value(element,
                                                       str_args[0])[0]
-                    str_def = ''
-                    if len(str_args) > 1:
-                        str_def = self.eval_string_value(element,
-                                                         str_args[1])[0]
                     val = self.lookup('strings', str_name)
                     if val == '':
-                        logger.warning("{} blank string".
-                                       format(str_name))
-                        val = str_def
+                        if len(str_args) > 1:
+                            val = self.eval_string_value(element,
+                                                         str_args[1])[0]
+                        else:
+                            logger.warning("{} blank string".
+                                           format(str_name))
 
                     if strname is not None:
                         strval += val
@@ -915,15 +913,14 @@ class Oven():
                     str_args = split(term.arguments, ',')
                     str_name = self.eval_string_value(element,
                                                       str_args[0])[0]
-                    str_def = ''
-                    if len(str_args) > 1:
-                        str_def = self.eval_string_value(element,
-                                                         str_args[1])[0]
                     val = self.lookup('strings', str_name)
                     if val == '':
-                        logger.warning("{} blank string".
-                                       format(str_name))
-                        val = str_def
+                        if len(str_args) > 1:
+                            val = self.eval_string_value(element,
+                                                         str_args[1])[0]
+                        else:
+                            logger.warning("{} blank string".
+                                           format(str_name))
                     if val != '':
                         actions.append(('string', val))
 

--- a/cnxeasybake/tests/html/default.log
+++ b/cnxeasybake/tests/html/default.log
@@ -13,7 +13,6 @@ cnx-easybake DEBUG IdentToken as string: itemclass
 cnx-easybake DEBUG Rule (11): li::after 
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
-cnx-easybake WARNING itemother blank string
 cnx-easybake DEBUG Rule (14): li::after 
 cnx-easybake DEBUG     default: content attr(string(itemtype))
 cnx-easybake DEBUG IdentToken as string: itemtype
@@ -31,7 +30,6 @@ cnx-easybake DEBUG IdentToken as string: itemclass
 cnx-easybake DEBUG Rule (11): li::after 
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
-cnx-easybake WARNING itemother blank string
 cnx-easybake DEBUG Rule (14): li::after 
 cnx-easybake DEBUG     default: content attr(string(itemtype))
 cnx-easybake DEBUG IdentToken as string: itemtype
@@ -49,7 +47,6 @@ cnx-easybake DEBUG IdentToken as string: itemclass
 cnx-easybake DEBUG Rule (11): li::after 
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
-cnx-easybake WARNING itemother blank string
 cnx-easybake DEBUG Rule (14): li::after 
 cnx-easybake DEBUG     default: content attr(string(itemtype))
 cnx-easybake DEBUG IdentToken as string: itemtype
@@ -67,7 +64,6 @@ cnx-easybake DEBUG IdentToken as string: itemclass
 cnx-easybake DEBUG Rule (11): li::after 
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
-cnx-easybake WARNING itemother blank string
 cnx-easybake DEBUG Rule (14): li::after 
 cnx-easybake DEBUG     default: content attr(string(itemtype))
 cnx-easybake DEBUG IdentToken as string: itemtype
@@ -85,7 +81,6 @@ cnx-easybake DEBUG IdentToken as string: itemclass
 cnx-easybake DEBUG Rule (11): li::after 
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
-cnx-easybake WARNING itemother blank string
 cnx-easybake DEBUG Rule (14): li::after 
 cnx-easybake DEBUG     default: content attr(string(itemtype))
 cnx-easybake DEBUG IdentToken as string: itemtype
@@ -103,7 +98,6 @@ cnx-easybake DEBUG IdentToken as string: itemclass
 cnx-easybake DEBUG Rule (11): li::after 
 cnx-easybake DEBUG     default: content "The other here: " string(itemother, "None!")
 cnx-easybake DEBUG IdentToken as string: itemother
-cnx-easybake WARNING itemother blank string
 cnx-easybake DEBUG Rule (14): li::after 
 cnx-easybake DEBUG     default: content attr(string(itemtype))
 cnx-easybake DEBUG IdentToken as string: itemtype


### PR DESCRIPTION
The warning regarding empty string values did not honor if the ruleset provided a default. Don't WARN if the user provided such a default.