### PR TITLE
Quieter logger when empty bucket occurs

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -975,7 +975,7 @@ class Oven():
                     target = serialize(term.arguments)
                     val, val_step = self.lookup('pending', target)
                     if val is None:
-                        logger.warning(u"{} empty bucket".format(target))
+                        logger.info(u"{} empty bucket".format(target))
                         continue
                     actions.extend(val)
                     del self.state[val_step]['pending'][target]
@@ -984,7 +984,7 @@ class Oven():
                     target = serialize(term.arguments)
                     val, val_step = self.lookup('pending', target)
                     if val is None:
-                        logger.warning(u"{} empty bucket".format(target))
+                        logger.info(u"{} empty bucket".format(target))
                         continue
                     for action in val:
                             if action[0] == 'move':
@@ -996,7 +996,7 @@ class Oven():
                     target = serialize(term.arguments)
                     val, val_step = self.lookup('pending', target)
                     if val is None:
-                        logger.warning(u"{} empty bucket".format(target))
+                        logger.info(u"{} empty bucket".format(target))
                         continue
                     wastebin.extend(val)
                     del self.state[val_step]['pending'][target]

--- a/cnxeasybake/tests/html/clear.log
+++ b/cnxeasybake/tests/html/clear.log
@@ -3,5 +3,5 @@ cnx-easybake DEBUG Rule (2): div[data-type="chapter"] section.key-equations
 cnx-easybake DEBUG     default: move-to trash
 cnx-easybake DEBUG Rule (6): body::after 
 cnx-easybake DEBUG     default: content clear(trash) clear(notrash)
-cnx-easybake WARNING notrash empty bucket
+cnx-easybake INFO notrash empty bucket
 cnx-easybake DEBUG Recipe default length: 5

--- a/cnxeasybake/tests/html/no_bucket.log
+++ b/cnxeasybake/tests/html/no_bucket.log
@@ -1,7 +1,7 @@
 cnx-easybake DEBUG Passes: ['default']
 cnx-easybake DEBUG Rule (11): div[data-type="chapter"]::before 
 cnx-easybake DEBUG     default: content pending(nope)
-cnx-easybake WARNING nope empty bucket
+cnx-easybake INFO nope empty bucket
 cnx-easybake DEBUG Rule (2): div[data-type="chapter"] section.practice-test 
 cnx-easybake DEBUG     default: move-to eoc-practice-test
 cnx-easybake DEBUG Rule (5): div[data-type="chapter"] section.key-equations 
@@ -15,7 +15,7 @@ cnx-easybake DEBUG     default: data-type composite-page
 cnx-easybake DEBUG IdentToken as string: composite-page
 cnx-easybake DEBUG     default: container div
 cnx-easybake DEBUG     default: content pending(bogus-no-such-bucket)
-cnx-easybake WARNING bogus-no-such-bucket empty bucket
+cnx-easybake INFO bogus-no-such-bucket empty bucket
 cnx-easybake DEBUG Rule (20): div[data-type="chapter"]::after 
 cnx-easybake DEBUG     default: class eoc-key-equations
 cnx-easybake DEBUG IdentToken as string: eoc-key-equations
@@ -25,5 +25,5 @@ cnx-easybake DEBUG     default: attr-my-type study-this
 cnx-easybake DEBUG IdentToken as string: study-this
 cnx-easybake DEBUG     default: container div
 cnx-easybake DEBUG     default: content pending(empty-bucket)
-cnx-easybake WARNING empty-bucket empty bucket
+cnx-easybake INFO empty-bucket empty bucket
 cnx-easybake DEBUG Recipe default length: 21

--- a/scripts/update-test-results
+++ b/scripts/update-test-results
@@ -17,6 +17,9 @@ then
 	esac
 fi
 
+# Activate virtualenv if not already in one
+[ -n "${VIRTUAL_ENV}" ] || source "${git_root}"/bin/activate
+
 rulename=${@:-*}
 
 for r in "${testdir}"/rulesets/${rulename}.css


### PR DESCRIPTION
This changes the logging level when an empty bucket occurs from WARNING to INFO.

These messages occur frequently as a normal part of baking books and I haven't investigated but I'm guessing it is not a bug. If it in fact is not a "bug" in the rulesets then the message should probably be suppressed but @helenemccarron would know for sure.


Also, I was unable to use `./scripts/update-test-results` to work properly so I manually edited the test files. It seems the virtualenv was running a different version of `oven.py` because the log files in the test directory ended up having the `WARNING` in them (even when I deleted the log file).

Oh, it seems my text editor strips trailing whitespace so maybe I should fix that ; (
- I looked into removing the trailing whitespace from easybake but it seems that it is added by `cssselect2` which is too far down the rabbit-hole for my skills 😄 