### PR TITLE
automatically add an id attribute when CSS asks for it

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -583,7 +583,16 @@ class Oven():
                     if len(att_args) > 1:
                         att_def = self.eval_string_value(element,
                                                          att_args[1])[0]
-                    strval += element.etree_element.get(att_name, att_def)
+                    att_val = element.etree_element.get(att_name, att_def)
+
+                    # If an element does not already have an id attribute but
+                    # the CSS is expecting one then automatically create one
+                    if att_name == u'id' and att_val is None:
+                        att_val = str(uuid4())
+                        logger.info("auto-added id attribute {}"
+                                    .format(att_val))
+
+                    strval += att_val
 
                 elif term.name == u'uuid':
                     strval += str(uuid4())


### PR DESCRIPTION
(posted to get feedback on the idea before writing tests 😄 )

I think it might be nice to automatically generate an `id` attribute if `attr(id)` is called and does not already exist (and maybe log a `WARNING`?)

There are a few places in the recipes where we create a new element and construct an id  just so we can link back and forth (maybe that is not the reason?)

Example: the [exercise problem/solution links](http://philschatz.com/gh-demo/styleguide/section-page.html#kssref-page-exercise)

What do folks think?

/cc @helenemccarron 