### PR TITLE
A test ruleset that adds dividers as siblings

### DIFF
--- a/cnxeasybake/tests/html/index_divider.log
+++ b/cnxeasybake/tests/html/index_divider.log
@@ -1,0 +1,90 @@
+cnx-easybake DEBUG Passes: ['0', u'2']
+cnx-easybake DEBUG Rule (1): div.index::before 
+cnx-easybake DEBUG     0: container span
+cnx-easybake DEBUG     0: class os-index-divider
+cnx-easybake DEBUG IdentToken as string: os-index-divider
+cnx-easybake DEBUG     0: content ", "
+cnx-easybake DEBUG     0: move-to indexDivider
+cnx-easybake DEBUG Rule (7): span.index-item:not(:last-child)::outside 
+cnx-easybake DEBUG     0: container span
+cnx-easybake DEBUG     0: content content() nodes(indexDivider)
+cnx-easybake DEBUG     0: class extra
+cnx-easybake DEBUG IdentToken as string: extra
+cnx-easybake DEBUG Rule (7): span.index-item:not(:last-child)::outside 
+cnx-easybake DEBUG     0: container span
+cnx-easybake DEBUG     0: content content() nodes(indexDivider)
+cnx-easybake DEBUG     0: class extra
+cnx-easybake DEBUG IdentToken as string: extra
+cnx-easybake DEBUG Rule (7): span.index-item:not(:last-child)::outside 
+cnx-easybake DEBUG     0: container span
+cnx-easybake DEBUG     0: content content() nodes(indexDivider)
+cnx-easybake DEBUG     0: class extra
+cnx-easybake DEBUG IdentToken as string: extra
+cnx-easybake DEBUG Rule (7): span.index-item:not(:last-child)::outside 
+cnx-easybake DEBUG     0: container span
+cnx-easybake DEBUG     0: content content() nodes(indexDivider)
+cnx-easybake DEBUG     0: class extra
+cnx-easybake DEBUG IdentToken as string: extra
+cnx-easybake DEBUG Rule (7): span.index-item:not(:last-child)::outside 
+cnx-easybake DEBUG     0: container span
+cnx-easybake DEBUG     0: content content() nodes(indexDivider)
+cnx-easybake DEBUG     0: class extra
+cnx-easybake DEBUG IdentToken as string: extra
+cnx-easybake DEBUG Rule (7): span.index-item:not(:last-child)::outside 
+cnx-easybake DEBUG     0: container span
+cnx-easybake DEBUG     0: content content() nodes(indexDivider)
+cnx-easybake DEBUG     0: class extra
+cnx-easybake DEBUG IdentToken as string: extra
+cnx-easybake DEBUG Rule (7): span.index-item:not(:last-child)::outside 
+cnx-easybake DEBUG     0: container span
+cnx-easybake DEBUG     0: content content() nodes(indexDivider)
+cnx-easybake DEBUG     0: class extra
+cnx-easybake DEBUG IdentToken as string: extra
+cnx-easybake DEBUG Rule (7): span.index-item:not(:last-child)::outside 
+cnx-easybake DEBUG     0: container span
+cnx-easybake DEBUG     0: content content() nodes(indexDivider)
+cnx-easybake DEBUG     0: class extra
+cnx-easybake DEBUG IdentToken as string: extra
+cnx-easybake DEBUG Rule (13): span.index-item:last-child::outside 
+cnx-easybake DEBUG     0: container span
+cnx-easybake DEBUG     0: content content()
+cnx-easybake DEBUG     0: class extra
+cnx-easybake DEBUG IdentToken as string: extra
+cnx-easybake DEBUG Recipe 0 length: 67
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (19): span.extra > *:pass(2) 
+cnx-easybake DEBUG     2: move-to realIndex
+cnx-easybake DEBUG Rule (23): div.index:deferred:pass(2) 
+cnx-easybake DEBUG     2: content pending(realIndex)
+cnx-easybake DEBUG Recipe 2 length: 19

--- a/cnxeasybake/tests/html/index_divider_cooked.html
+++ b/cnxeasybake/tests/html/index_divider_cooked.html
@@ -1,0 +1,6 @@
+<html>
+    <body>
+        <div class="index"><span class="index-item">1</span><span class="os-index-divider">, </span><span class="index-item">2</span><span class="os-index-divider">, </span><span class="index-item">3</span><span class="os-index-divider">, </span><span class="index-item">4</span><span class="os-index-divider">, </span><span class="index-item">5</span><span class="os-index-divider">, </span><span class="index-item">6</span><span class="os-index-divider">, </span><span class="index-item">7</span><span class="os-index-divider">, </span><span class="index-item">8</span><span class="os-index-divider">, </span><span class="index-item">9</span></div>
+        
+    </body>
+</html>

--- a/cnxeasybake/tests/html/index_divider_raw.html
+++ b/cnxeasybake/tests/html/index_divider_raw.html
@@ -1,0 +1,9 @@
+<html>
+    <body>
+        <div class="index">
+            <span class="index-item">1</span><span class="index-item">2</span><span class="index-item">3</span><span class="index-item">4</span><span class="index-item">5</span><span class="index-item">6</span><span class="index-item">7</span><span class="index-item">8</span><span class="index-item">9</span>
+        </div>
+        
+    </body>
+</html>
+

--- a/cnxeasybake/tests/rulesets/index_divider.css
+++ b/cnxeasybake/tests/rulesets/index_divider.css
@@ -1,0 +1,25 @@
+div.index::before {
+    container: span;
+    class: os-index-divider;
+    content: ", ";
+    move-to: indexDivider;
+}
+span.index-item:not(:last-child)::outside {
+    container: span;
+    content: content() nodes(indexDivider);
+    class: extra;
+}
+
+span.index-item:last-child::outside {
+    container: span;
+    content: content();
+    class: extra;
+}
+
+span.extra > *:pass(2) {
+    move-to: realIndex;
+}
+
+div.index:deferred:pass(2) {
+    content: pending(realIndex)
+}


### PR DESCRIPTION
This may not be the most obvious thing to do, but combining `::outside` and two passes, the included test adds commas between a list of child nodes, with the commas added as siblings of the items, with their own wrapper nodes.