### PR TITLE
support CSS coverage output file

### DIFF
--- a/cnxeasybake/scripts/main.py
+++ b/cnxeasybake/scripts/main.py
@@ -12,7 +12,8 @@ from cnxeasybake import Oven, __version__
 logger = logging.getLogger('cnx-easybake')
 
 
-def easybake(css_in, html_in=sys.stdin, html_out=sys.stdout, last_step=None):
+def easybake(css_in, html_in=sys.stdin, html_out=sys.stdout, last_step=None,
+             coverage_file=None):
     """Process the given HTML file stream with the css stream."""
     html_parser = etree.HTMLParser(encoding="utf-8")
     html_doc = etree.HTML(html_in.read(), html_parser)
@@ -21,6 +22,12 @@ def easybake(css_in, html_in=sys.stdin, html_out=sys.stdout, last_step=None):
 
     # serialize out HTML
     print (etree.tostring(html_doc, method="html"), file=html_out)
+
+    # generate CSS coverage_file file
+    if coverage_file:
+        print('SF:{}'.format(css_in.name), file=coverage_file)
+        print(oven.get_coverage_report(), file=coverage_file)
+        print('end_of_record', file=coverage_file)
 
 
 def main(argv=None):
@@ -45,6 +52,9 @@ def main(argv=None):
                         help='Stop baking just before given pass name')
     parser.add_argument('-d', '--debug', action='store_true',
                         help='Send debugging info to stderr')
+    parser.add_argument('-c', '--coverage-file', metavar='coverage.lcov',
+                        type=argparse.FileType('w'),
+                        help="output coverage file (lcov format)")
     args = parser.parse_args(argv)
 
     formatter = logging.Formatter('%(name)s %(levelname)s %(message)s')
@@ -55,7 +65,9 @@ def main(argv=None):
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
-    easybake(args.css_rules, args.html_in, args.html_out, args.stop_at)
+    easybake(args.css_rules, args.html_in, args.html_out, args.stop_at,
+             args.coverage_file)
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/cnxeasybake/tests/README.md
+++ b/cnxeasybake/tests/README.md
@@ -5,4 +5,4 @@ To generate a new ruleset test, create a `CSS` file  in the `rulesets` folder, n
 ```
 $ ./scripts/update-test-results testname  # From the git root
 ```
- If the testname is omitted, all CSS files will be updated.
+ If the testname is omitted, results for all CSS files will be updated.

--- a/cnxeasybake/tests/html/two_pass.log
+++ b/cnxeasybake/tests/html/two_pass.log
@@ -41,17 +41,17 @@ cnx-easybake DEBUG     second: counter-increment page
 cnx-easybake DEBUG     second: container h1
 cnx-easybake DEBUG     second: content "Chapter " counter(page)
 cnx-easybake DEBUG     second: attr-id "myid" counter(page)
-cnx-easybake DEBUG Rule (34): :pass("second") div[data-type="page"]::before, :pass("second") div[data-type="composite-page"]::before 
+cnx-easybake DEBUG Rule (35): :pass("second") div[data-type="page"]::before, :pass("second") div[data-type="composite-page"]::before 
 cnx-easybake DEBUG     second: counter-increment page
 cnx-easybake DEBUG     second: container h1
 cnx-easybake DEBUG     second: content "Chapter " counter(page)
 cnx-easybake DEBUG     second: attr-id "myid" counter(page)
-cnx-easybake DEBUG Rule (34): :pass("second") div[data-type="page"]::before, :pass("second") div[data-type="composite-page"]::before 
+cnx-easybake DEBUG Rule (35): :pass("second") div[data-type="page"]::before, :pass("second") div[data-type="composite-page"]::before 
 cnx-easybake DEBUG     second: counter-increment page
 cnx-easybake DEBUG     second: container h1
 cnx-easybake DEBUG     second: content "Chapter " counter(page)
 cnx-easybake DEBUG     second: attr-id "myid" counter(page)
-cnx-easybake DEBUG Rule (5): :pass("first") body::after, :pass("second") body::after 
+cnx-easybake DEBUG Rule (6): :pass("first") body::after, :pass("second") body::after 
 cnx-easybake DEBUG     second: content "Two passes, doubled!"
 cnx-easybake DEBUG Rule (9): :pass("second") body::after 
 cnx-easybake DEBUG     second: content string(onestring)

--- a/cnxeasybake/tests/html/two_selectors.log
+++ b/cnxeasybake/tests/html/two_selectors.log
@@ -1,9 +1,9 @@
 cnx-easybake DEBUG Passes: ['default']
-cnx-easybake DEBUG Rule (2): section[data-type="glossary"], section[data-type="summary"] 
+cnx-easybake DEBUG Rule (3): section[data-type="glossary"], section[data-type="summary"] 
 cnx-easybake DEBUG     default: move-to trash
 cnx-easybake DEBUG Rule (2): section[data-type="glossary"], section[data-type="summary"] 
 cnx-easybake DEBUG     default: move-to trash
-cnx-easybake DEBUG Rule (2): section[data-type="glossary"], section[data-type="summary"] 
+cnx-easybake DEBUG Rule (3): section[data-type="glossary"], section[data-type="summary"] 
 cnx-easybake DEBUG     default: move-to trash
 cnx-easybake DEBUG Rule (6): body::after 
 cnx-easybake DEBUG     default: content clear(trash)

--- a/cnxeasybake/tests/test_cli.py
+++ b/cnxeasybake/tests/test_cli.py
@@ -6,12 +6,44 @@
 # See LICENCE.txt for details.
 # ###
 """CLI tests."""
+import logging
 import os
+import sys
+import tempfile
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+
+from contextlib import contextmanager
+from io import StringIO
+
+from testfixtures import LogCapture
+
+
+# noqa from http://stackoverflow.com/questions/4219717/how-to-assert-output-with-nosetest-unittest-in-python
+@contextmanager
+def captured_output():
+    if sys.version_info[0] == 3:
+        new_out, new_err = StringIO(), StringIO()
+    else:
+        from io import BytesIO
+        new_out, new_err = BytesIO(), BytesIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        for handler in logging.root.handlers:
+            if hasattr(handler, 'stream'):
+                if handler.stream == sys.stderr:
+                    handler.stream = new_err
+                elif handler.stream == sys.stdout:
+                    handler.stream = new_out
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+        for handler in logging.root.handlers:
+            if hasattr(handler, 'stream'):
+                if handler.stream == new_err:
+                    handler.stream = old_err
+                elif handler.stream == new_out:
+                    handler.stream = old_out
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -25,14 +57,99 @@ class CliTestCase(unittest.TestCase):
         from cnxeasybake.scripts.main import main
         return main
 
-    @mock.patch('sys.stderr')
-    def test_help(self, mocked_stderr):
+    def test_success(self):
         """Call cli with basic successful run."""
         os.chdir(here)
-        args = ['rulesets/empty.css', 'html/empty_raw.html', '/dev/null']
-        return_code = self.target(args)
-        self.assertEqual(return_code, None)
+        with captured_output() as (out, err):
+            args = ['rulesets/empty.css', 'html/empty_raw.html', '/dev/null']
+            self.target(args)
+            stdout = str(out.getvalue())
+            stderr = str(err.getvalue())
 
-        # Ensure a meaningfully message was sent to stderr.
-        # expected_message_line = 'too few arguments'
-        # mocked_stderr.write.assert_any_call(expected_message_line)
+        self.assertEqual(stderr, '')
+        self.assertEqual(stdout, '')
+
+    def test_noargs(self):
+        """Check basic usage message."""
+        os.chdir(here)
+        with captured_output() as (out, err):
+            args = []
+            try:
+                self.target(args)
+            except:
+                pass
+            stdout = str(out.getvalue())
+            stderr = str(err.getvalue())
+
+        usage_message = """usage: setup.py [-h] [-v] [-s <pass>] [-d] [-c coverage.lcov]
+                css_rules [html_in] [html_out]
+setup.py: error: too few arguments
+"""
+
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr, usage_message)
+
+    def test_help(self):
+        """Check help usage message."""
+        os.chdir(here)
+        with captured_output() as (out, err):
+            args = ['-h']
+            try:
+                self.target(args)
+            except:
+                pass
+            stdout = str(out.getvalue())
+            stderr = str(err.getvalue())
+
+        usage_message = """usage: setup.py [-h] [-v] [-s <pass>] [-d] [-c coverage.lcov]
+                css_rules [html_in] [html_out]
+
+Process raw HTML to baked (embedded numbering and collation)
+
+positional arguments:
+  css_rules             CSS3 ruleset stylesheet recipe
+  html_in               raw HTML file to bake (default stdin)
+  html_out              baked HTML file output (default stdout)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --version         Report the library version
+  -s <pass>, --stop-at <pass>
+                        Stop baking just before given pass name
+  -d, --debug           Send debugging info to stderr
+  -c coverage.lcov, --coverage-file coverage.lcov
+                        output coverage file (lcov format)
+"""
+
+        self.assertEqual(stderr, '')
+        self.assertEqual(stdout, usage_message)
+
+    def test_coverage(self):
+        """Call cli coverage output."""
+        os.chdir(here)
+        fs_pointer, lcov_filepath = tempfile.mkstemp('.lcov')
+        self.addCleanup(os.remove, lcov_filepath)
+
+        args = ['--coverage-file', lcov_filepath, 'rulesets/clear.css',
+                'html/clear_raw.html', '/dev/null']
+        with captured_output() as (out, err):
+            try:
+                self.target(args)
+            except:
+                pass
+            stdout = str(out.getvalue())
+            stderr = str(err.getvalue())
+
+        coverage_expected = """SF:rulesets/clear.css
+DA:2,0
+DA:6,0
+DA:2,1
+DA:3,1
+DA:6,1
+DA:7,1
+end_of_record
+"""
+        coverage_actual = os.read(fs_pointer, 8192)
+        self.assertEqual(stderr, '')
+        self.assertEqual(stdout, '')
+        self.assertEqual(coverage_actual, coverage_expected)

--- a/cnxeasybake/tests/test_rulesets.py
+++ b/cnxeasybake/tests/test_rulesets.py
@@ -17,7 +17,6 @@ TEST_RULESET_DIR = os.path.join(here, 'rulesets')
 TEST_HTML_DIR = os.path.join(here, 'html')
 
 logger = logging.getLogger('cnx-easybake')
-logger.setLevel(logging.DEBUG)
 
 
 def tidy(input_):
@@ -57,10 +56,12 @@ class RulesetTestCase(unittest.TestCase):
     def setUp(cls):
         """Setup logcap."""
         cls.logcap = LogCapture()
+        logger.setLevel(logging.DEBUG)
 
     def tearDown(cls):
         """Teardown logcap."""
         cls.logcap.uninstall()
+        logger.setLevel(logging.WARN)
 
     @classmethod
     def generate_tests(cls):
@@ -81,9 +82,7 @@ class RulesetTestCase(unittest.TestCase):
 
             test_name = os.path.basename(filename_no_ext)
             log_fname = '{}.log'.format(test_name)
-            import codecs
-            with codecs.open(os.path.join(TEST_HTML_DIR, log_fname),
-                             'rb', encoding='utf-8') as f_log:
+            with open(os.path.join(TEST_HTML_DIR, log_fname)) as f_log:
                 logs = (tuple(line[:-1].split(' ', 2)) for line in f_log)
                 logs = tuple(logs)
 


### PR DESCRIPTION
Optionally generates a CSS coverage file which shows which selectors were matched when baking.

![image](https://cloud.githubusercontent.com/assets/253202/19982116/2601a30c-a1db-11e6-86e4-36677c235270.png)

It currently only shows the selectors that were matched, not the declarations but it is still vastly more precise than what `cnx-recipes` was doing before because this marks the selectors as they are being used.

I was not sure about the best way to store the coverage lines (I just built an array of strings of the format `DA:#,#` and then joined them outside of the main lib) but let me know and I'll fix it!

# Notes

- this does not add the (optional) `LH: #` and `LF: #` fields defined in the lcov format (they're a little harder to calculate)
- this does not try to minimize the `.lcov` file size