### PR TITLE
allows CLI argument to generate repeatable ids

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -87,14 +87,24 @@ class Oven():
     them to an HTML file.
     """
 
-    def __init__(self, css_in=None):
+    def __init__(self, css_in=None, use_repeatable_ids=False):
         """Initialize oven, with optional inital CSS."""
         self.coverage_lines = []
+        self.use_repeatable_ids = use_repeatable_ids
+        self.repeatable_id_counter = 0
         if css_in:
             self.update_css(css_in, clear_css=True)  # clears state as well
         else:
             self.matchers = {}
             self.clear_state()
+
+    def generate_id(self):
+        """Generate a fresh id"""
+        if self.use_repeatable_ids:
+            self.repeatable_id_counter += 1
+            return 'autobaked-{}'.format(self.repeatable_id_counter)
+        else:
+            return str(uuid4())
 
     def clear_state(self):
         """Clear the recipe state."""
@@ -614,7 +624,7 @@ class Oven():
                     strval += element.etree_element.get(att_name, att_def)
 
                 elif term.name == u'uuid':
-                    strval += str(uuid4())
+                    strval += self.generate_id()
 
                 elif term.name == u'content':
                     strval += etree.tostring(element.etree_element,
@@ -995,7 +1005,7 @@ class Oven():
                     actions.append(('string', att_val))
 
                 elif term.name == u'uuid':
-                    actions.append(('string', str(uuid4())))
+                    actions.append(('string', self.generate_id()))
 
                 elif term.name == u'first-letter':
                     tmpstr = self.eval_string_value(element, term.arguments)

--- a/cnxeasybake/scripts/main.py
+++ b/cnxeasybake/scripts/main.py
@@ -67,6 +67,9 @@ def main(argv=None):
                         type=FileTypeExt('w'),
                         help="output coverage file (lcov format). If "
                         "filename starts with '+', append coverage info.")
+    parser.add_argument('--use-repeatable-ids', action='store_true',
+                        help="use repeatable id attributes instead of uuids "
+                        "which is useful for diffing")
     args = parser.parse_args(argv)
 
     formatter = logging.Formatter('%(name)s %(levelname)s %(message)s')

--- a/cnxeasybake/tests/test_cli.py
+++ b/cnxeasybake/tests/test_cli.py
@@ -80,6 +80,7 @@ class CliTestCase(unittest.TestCase):
             stderr = str(err.getvalue())
 
         usage_message = """usage: setup.py [-h] [-v] [-s <pass>] [-d] [-c coverage.lcov]
+                [--use-repeatable-ids]
                 css_rules [html_in] [html_out]
 setup.py: error: too few arguments
 """
@@ -100,6 +101,7 @@ setup.py: error: too few arguments
             stderr = str(err.getvalue())
 
         usage_message = """usage: setup.py [-h] [-v] [-s <pass>] [-d] [-c coverage.lcov]
+                [--use-repeatable-ids]
                 css_rules [html_in] [html_out]
 
 Process raw HTML to baked (embedded numbering and collation)
@@ -118,6 +120,8 @@ optional arguments:
   -c coverage.lcov, --coverage-file coverage.lcov
                         output coverage file (lcov format). If filename starts
                         with '+', append coverage info.
+  --use-repeatable-ids  use repeatable id attributes instead of uuids which is
+                        useful for diffing
 """
 
         self.assertEqual(stderr, '')


### PR DESCRIPTION
Fixes #35

I've been using this (well, without the CLI arg) to regression-test the refactoring work in https://github.com/Connexions/cnx-recipes/pull/107 (using https://github.com/Connexions/cnx-recipes/pull/104 ).

Once this is merged I can update https://github.com/Connexions/cnx-recipes/pull/104 to use the CLI arg