### PR TITLE
provides a more-descriptive error when `::outside` is executed twice

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -1265,7 +1265,13 @@ def grouped_insert(t, value):
 
     elif t.location == 'outside':
         value.tail = t.tree.tail
-        t.parent.insert(t.parent.index(t.tree), value)
+        try:
+            t.parent.insert(t.parent.index(t.tree), value)
+        except (ValueError):
+            logger.error(u"Element being wrapped no longer exists in the DOM."
+                         u" It could be that this element was matched twice"
+                         u" by 2 selectors.")
+            raise
         value.append(t.tree)
 
     elif t.location == 'before':


### PR DESCRIPTION
... on the same element.

This does not actually fix the problem (matching `::outside` twice should not cause an error).

refs #48