### PR TITLE
correctly store deferred modifications to string and counter values

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -430,11 +430,11 @@ class Oven():
                     for counter, val in self.state[s_step]['counters'].items():
                         if (counter not in temp_counters or
                                 temp_counters[counter] != val):
-                            self.state['counters'][element_id][counter] = val
+                            self.state['counters'][element_id][s_step]['counters'][counter] = val  # NOQA
                     for string, val in self.state[s_step]['strings'].items():
                         if (string not in temp_strings or
                                 temp_strings[string] != val):
-                            self.state['strings'][element_id][string] = val
+                            self.state['strings'][element_id][s_step]['strings'][string] = val  # NOQA
 
         if depth == 0:
             self.state[step]['recipe'] = True  # FIXME should ref HTML tree

--- a/cnxeasybake/tests/html/deferred_and_target.log
+++ b/cnxeasybake/tests/html/deferred_and_target.log
@@ -1,0 +1,8 @@
+cnx-easybake DEBUG Passes: ['default']
+cnx-easybake DEBUG Rule (2): a[href] 
+cnx-easybake DEBUG     default: content target-string(attr(href), stringName)
+cnx-easybake DEBUG IdentToken as string: href
+cnx-easybake DEBUG IdentToken as string: stringName
+cnx-easybake DEBUG Rule (5): div:deferred 
+cnx-easybake DEBUG     default: string-set stringName "hello"
+cnx-easybake DEBUG Recipe default length: 4

--- a/cnxeasybake/tests/html/deferred_and_target_baked.html
+++ b/cnxeasybake/tests/html/deferred_and_target_baked.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <a href="#id123">hello</a>
+  <div id="id123"></div>
+</body>
+</html>

--- a/cnxeasybake/tests/html/deferred_and_target_raw.html
+++ b/cnxeasybake/tests/html/deferred_and_target_raw.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <a href="#id123"/>
+  <div id="id123"/>
+</body>
+</html>

--- a/cnxeasybake/tests/rulesets/deferred_and_target.css
+++ b/cnxeasybake/tests/rulesets/deferred_and_target.css
@@ -1,0 +1,7 @@
+/* Deferred pseudo class that is used by a target */
+a[href] {
+  content: target-string(attr(href), stringName);
+}
+div:deferred {
+  string-set: stringName "hello";
+}


### PR DESCRIPTION
In order to implement target-* functions, the value of all variables is stored at each node that has an id (and therefore, may be the target for a target-string or target-counter call later). For proper semantics, this needs to be stored before children are processed. However, :deferred rules must be allowed to change the values. These occur _after_ children have run. The code to detect such changes and transfer them to the indexed-by-id store was buggy, and broke the nested-keys structure. This PR fixes it. Still needs tests.