### PR TITLE
implementation of ::inside wrapper pseudo element

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -364,11 +364,21 @@ class Oven():
                     method = self.find_method(decl)
                     method(element, decl, 'outside')
 
+        # Do inside
+        if 'inside' in matching_rules:
+            for rule, declarations in matching_rules.get('inside'):
+                self.record_coverage(rule)
+                self.push_pending_elem(element, 'inside')
+                for decl in declarations:
+                    method = self.find_method(decl)
+                    method(element, decl, 'inside')
+
         # Do deferred
         if ('deferred' in matching_rules or
              'after_deferred' in matching_rules or  # NOQA
              'before_deferred' in matching_rules or
-             'outside_deferred' in matching_rules):
+             'outside_deferred' in matching_rules or
+             'inside_deferred' in matching_rules):
 
             # store strings and counters, in case a deferred rule changes one
             if element_id:
@@ -423,6 +433,16 @@ class Oven():
                     for decl in declarations:
                         method = self.find_method(decl)
                         method(element, decl, 'outside')
+
+            # Do inside_deferred
+            if 'inside_deferred' in matching_rules:
+                for rule, declarations in \
+                        matching_rules.get('inside_deferred'):
+                    self.record_coverage(rule)
+                    self.push_pending_elem(element, 'inside')
+                    for decl in declarations:
+                        method = self.find_method(decl)
+                        method(element, decl, 'inside')
 
             # Did a deferred rule change a stored variable?
             if element_id:
@@ -1018,6 +1038,8 @@ class Oven():
                         actions.append(('content', mycopy))
                     elif pseudo == 'outside':
                         actions.append(('move', element.etree_element))
+                    elif pseudo == 'inside':
+                        pass  # FIXME  - work out semantics for this
                     else:
                         actions.append(('content', None))
 
@@ -1262,6 +1284,15 @@ def grouped_insert(t, value):
 
     elif t.sort and t.sort(value) is not None:
         insert_sort(value, t.tree, t.sort)
+
+    elif t.location == 'inside':
+        for child in t.tree:
+            value.append(child)
+        value.text = t.tree.text
+        t.tree.text = None
+        value.tail = t.tree.tail
+        t.tree.tail = None
+        t.tree.append(value)
 
     elif t.location == 'outside':
         value.tail = t.tree.tail

--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -960,7 +960,7 @@ class Oven():
 
         wastebin = []
         elem = self.current_target().tree
-        if elem == element.etree_element:
+        if elem == element.etree_element or pseudo == 'inside':
             actions.append(('clear', elem))
 
         if pseudo:
@@ -1038,8 +1038,6 @@ class Oven():
                         actions.append(('content', mycopy))
                     elif pseudo == 'outside':
                         actions.append(('move', element.etree_element))
-                    elif pseudo == 'inside':
-                        pass  # FIXME  - work out semantics for this
                     else:
                         actions.append(('content', None))
 

--- a/cnxeasybake/tests/html/inside.log
+++ b/cnxeasybake/tests/html/inside.log
@@ -1,0 +1,20 @@
+cnx-easybake DEBUG Passes: ['default']
+cnx-easybake DEBUG Rule (2): div[data-type="chapter"] div[data-type="note"]::after 
+cnx-easybake DEBUG     default: content "This is a note title"
+cnx-easybake DEBUG     default: container span
+cnx-easybake DEBUG     default: class note-title
+cnx-easybake DEBUG IdentToken as string: note-title
+cnx-easybake DEBUG     default: move-to note-title
+cnx-easybake DEBUG Rule (8): div[data-type="chapter"] div[data-type="note"]::after 
+cnx-easybake DEBUG     default: content "This is a note caption"
+cnx-easybake DEBUG     default: container span
+cnx-easybake DEBUG     default: class note-caption
+cnx-easybake DEBUG IdentToken as string: note-caption
+cnx-easybake DEBUG     default: move-to note-caption
+cnx-easybake DEBUG Rule (14): div[data-type="chapter"] div[data-type="note"]::inside 
+cnx-easybake DEBUG     default: class note-body-wrapper
+cnx-easybake DEBUG IdentToken as string: note-body-wrapper
+cnx-easybake DEBUG     default: container div
+cnx-easybake DEBUG Rule (19): div[data-type="chapter"] div[data-type="note"]:deferred 
+cnx-easybake DEBUG     default: content pending(note-title) content() pending(note-caption)
+cnx-easybake DEBUG Recipe default length: 20

--- a/cnxeasybake/tests/html/inside.log
+++ b/cnxeasybake/tests/html/inside.log
@@ -1,4 +1,10 @@
 cnx-easybake DEBUG Passes: ['default']
+cnx-easybake DEBUG Rule (26): div[data-type="chapter"] div[data-type="alert"]::inside 
+cnx-easybake DEBUG     default: class alert-body-wrapper
+cnx-easybake DEBUG IdentToken as string: alert-body-wrapper
+cnx-easybake DEBUG     default: content "before text" content() "after text"
+cnx-easybake DEBUG Rule (19): div[data-type="chapter"] div[data-type="note"] 
+cnx-easybake DEBUG     default: content "Hardcoded title" content() "hardcoded caption"
 cnx-easybake DEBUG Rule (2): div[data-type="chapter"] div[data-type="note"]::after 
 cnx-easybake DEBUG     default: content "This is a note title"
 cnx-easybake DEBUG     default: container span
@@ -15,6 +21,6 @@ cnx-easybake DEBUG Rule (14): div[data-type="chapter"] div[data-type="note"]::in
 cnx-easybake DEBUG     default: class note-body-wrapper
 cnx-easybake DEBUG IdentToken as string: note-body-wrapper
 cnx-easybake DEBUG     default: container div
-cnx-easybake DEBUG Rule (19): div[data-type="chapter"] div[data-type="note"]:deferred 
+cnx-easybake DEBUG Rule (22): div[data-type="chapter"] div[data-type="note"]:deferred 
 cnx-easybake DEBUG     default: content pending(note-title) content() pending(note-caption)
-cnx-easybake DEBUG Recipe default length: 20
+cnx-easybake DEBUG Recipe default length: 33

--- a/cnxeasybake/tests/html/inside_baked.html
+++ b/cnxeasybake/tests/html/inside_baked.html
@@ -1,0 +1,35 @@
+<html>
+<head>
+<title>Two afters</title>
+</head>
+<body>
+<div data-type="chapter">
+    <div data-type="page">
+        <section class="this one doesn't move">
+            <p>Stuff that stays, as well</p>
+        </section>
+    </div>
+    <div data-type="page">
+        <section class="practice-test">
+            <p>Hi, I'm a practice test section, too</p>
+            <div data-type="note"><span class="note-title">This is a note title</span><div class="note-body-wrapper">
+                This is a note with a table in it.
+                <table>
+                  <tr>
+                    <td>Jill</td>
+                    <td>Smith</td> 
+                    <td>50</td>
+                  </tr>
+                  <tr>
+                    <td>Eve</td>
+                    <td>Jackson</td> 
+                    <td>94</td>
+                  </tr>
+                </table>
+                Tail text, too.
+            </div>
+        <span class="note-caption">This is a note caption</span></div></section>
+    </div>
+</div>
+</body>
+</html>

--- a/cnxeasybake/tests/html/inside_baked.html
+++ b/cnxeasybake/tests/html/inside_baked.html
@@ -7,12 +7,16 @@
     <div data-type="page">
         <section class="this one doesn't move">
             <p>Stuff that stays, as well</p>
-        </section>
+            <div data-type="alert"><div class="alert-body-wrapper">before text
+                <p>Some text in an alert div, to test content: content()</p>
+                With tail text.
+            after text</div>
+        </div></section>
     </div>
     <div data-type="page">
         <section class="practice-test">
             <p>Hi, I'm a practice test section, too</p>
-            <div data-type="note"><span class="note-title">This is a note title</span><div class="note-body-wrapper">
+            <div data-type="note"><span class="note-title">This is a note title</span><div class="note-body-wrapper">Hardcoded title
                 This is a note with a table in it.
                 <table>
                   <tr>
@@ -27,7 +31,7 @@
                   </tr>
                 </table>
                 Tail text, too.
-            </div>
+            hardcoded caption</div>
         <span class="note-caption">This is a note caption</span></div></section>
     </div>
 </div>

--- a/cnxeasybake/tests/html/inside_raw.html
+++ b/cnxeasybake/tests/html/inside_raw.html
@@ -7,6 +7,10 @@
     <div data-type="page">
         <section class="this one doesn't move">
             <p>Stuff that stays, as well</p>
+            <div data-type="alert">
+                <p>Some text in an alert div, to test content: content()</p>
+                With tail text.
+            </div>
         </section>
     </div>
     <div data-type="page">

--- a/cnxeasybake/tests/html/inside_raw.html
+++ b/cnxeasybake/tests/html/inside_raw.html
@@ -1,0 +1,35 @@
+<html>
+<head>
+<title>Two afters</title>
+</head>
+<body>
+<div data-type="chapter">
+    <div data-type="page">
+        <section class="this one doesn't move">
+            <p>Stuff that stays, as well</p>
+        </section>
+    </div>
+    <div data-type="page">
+        <section class="practice-test">
+            <p>Hi, I'm a practice test section, too</p>
+            <div data-type="note">
+                This is a note with a table in it.
+                <table>
+                  <tr>
+                    <td>Jill</td>
+                    <td>Smith</td> 
+                    <td>50</td>
+                  </tr>
+                  <tr>
+                    <td>Eve</td>
+                    <td>Jackson</td> 
+                    <td>94</td>
+                  </tr>
+                </table>
+                Tail text, too.
+            </div>
+        </section>
+    </div>
+</div>
+</body>
+</html>

--- a/cnxeasybake/tests/rulesets/inside.css
+++ b/cnxeasybake/tests/rulesets/inside.css
@@ -16,6 +16,15 @@ div[data-type='chapter'] div[data-type='note']::inside {
   container: div;
 }
 
+div[data-type='chapter'] div[data-type='note'] {
+  content: 'Hardcoded title' content() 'hardcoded caption';
+}
 div[data-type='chapter'] div[data-type='note']:deferred {
   content: pending(note-title) content() pending(note-caption);
 }
+
+div[data-type='chapter'] div[data-type='alert']::inside {
+  class: alert-body-wrapper;
+  content: "before text" content() "after text";
+}
+

--- a/cnxeasybake/tests/rulesets/inside.css
+++ b/cnxeasybake/tests/rulesets/inside.css
@@ -1,0 +1,21 @@
+/* Wrapping a div around an element */
+div[data-type='chapter'] div[data-type='note']::after {
+  content: "This is a note title";
+  container: span;
+  class: note-title;
+  move-to: note-title;
+}
+div[data-type='chapter'] div[data-type='note']::after {
+  content: "This is a note caption";
+  container: span;
+  class: note-caption;
+  move-to: note-caption;
+}
+div[data-type='chapter'] div[data-type='note']::inside {
+  class: note-body-wrapper;
+  container: div;
+}
+
+div[data-type='chapter'] div[data-type='note']:deferred {
+  content: pending(note-title) content() pending(note-caption);
+}


### PR DESCRIPTION
This implements a new pseudo-element, that allows adding a wrapping element to all the children of a given selected element. This is useful when adding  additional children (via ::before or ::after), allowing the existing set of children to be distinguished from additions.