### PR TITLE
Fix integer steps

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -205,8 +205,12 @@ class Oven():
         """Apply recipes to HTML tree. Will build recipes if needed."""
 
         if last_step is not None:
-            self.state['steps'] = [s for s in self.state['steps']
-                                   if s < last_step]
+            try:
+                self.state['steps'] = [s for s in self.state['steps']
+                                       if int(s) < int(last_step)]
+            except ValueError:
+                self.state['steps'] = [s for s in self.state['steps']
+                                       if s < last_step]
         for step in self.state['steps']:
             self.state['current_step'] = step
             self.state['scope'].insert(0, step)

--- a/cnxeasybake/tests/test_cli.py
+++ b/cnxeasybake/tests/test_cli.py
@@ -119,7 +119,7 @@ optional arguments:
 """
 
         self.assertEqual(stderr, '')
-        self.assertIn(usage_message, stdout)
+        self.assertIn(usage_message.replace(' ', ''), stdout.replace(' ', ''))
 
     def test_coverage(self):
         """Call cli coverage output."""


### PR DESCRIPTION
fix a bug with the 'stop at step' debugging option. Without this, --stop 8 went ahead and did 1 ...7, 10, 100. Oops.