### PR TITLE
do not move tail text onto an ::inside pseudo element

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -1279,7 +1279,7 @@ def grouped_insert(t, value):
             val_parent = value.getparent()
             if val_parent is not None:
                 val_parent.text = (val_parent.text or '') + value.tail
-    value.tail = None
+        value.tail = None
     if t.isgroup and t.sort(value) is not None:
         if t.groupby:
             for child in t.tree:
@@ -1308,8 +1308,6 @@ def grouped_insert(t, value):
             value.append(child)
         value.text = t.tree.text
         t.tree.text = None
-        value.tail = t.tree.tail
-        t.tree.tail = None
         t.tree.append(value)
 
     elif t.location == 'outside':

--- a/cnxeasybake/tests/html/inside_baked.html
+++ b/cnxeasybake/tests/html/inside_baked.html
@@ -9,9 +9,10 @@
             <p>Stuff that stays, as well</p>
             <div data-type="alert"><div class="alert-body-wrapper">before text
                 <p>Some text in an alert div, to test content: content()</p>
-                With tail text.
-            after text</div>
-        </div></section>
+                With child tail text. (should be wrapped)
+            after text</div></div>
+            And target tail text. (should not be wrapped)
+        </section>
     </div>
     <div data-type="page">
         <section class="practice-test">
@@ -31,8 +32,8 @@
                   </tr>
                 </table>
                 Tail text, too.
-            hardcoded caption</div>
-        <span class="note-caption">This is a note caption</span></div></section>
+            hardcoded caption</div><span class="note-caption">This is a note caption</span></div>
+        </section>
     </div>
 </div>
 </body>

--- a/cnxeasybake/tests/html/inside_raw.html
+++ b/cnxeasybake/tests/html/inside_raw.html
@@ -9,8 +9,9 @@
             <p>Stuff that stays, as well</p>
             <div data-type="alert">
                 <p>Some text in an alert div, to test content: content()</p>
-                With tail text.
+                With child tail text. (should be wrapped)
             </div>
+            And target tail text. (should not be wrapped)
         </section>
     </div>
     <div data-type="page">


### PR DESCRIPTION
 - should stay after the targeted element