### PR TITLE
Add support for namespace prefixes in attr()

### DIFF
--- a/cnxeasybake/oven.py
+++ b/cnxeasybake/oven.py
@@ -712,6 +712,15 @@ class Oven():
                     if len(att_args) > 1:
                         att_def = self.eval_string_value(element,
                                                          att_args[1])[0]
+                    if '|' in att_name:
+                        ns, att = att_name.split('|')
+                        try:
+                            ns = self.css_namespaces[ns]
+                        except KeyError:
+                            logger.warning(u"Undefined namespace prefix {}"
+                                           .format(ns).encode('utf-8'))
+                            continue
+                        att_name = etree.QName(ns, att)
                     strval += element.etree_element.get(att_name, att_def)
 
                 elif term.name == u'uuid':
@@ -840,6 +849,15 @@ class Oven():
                         if len(att_args) > 1:
                             att_def = self.eval_string_value(element,
                                                              att_args[1])[0]
+                        if '|' in att_name:
+                            ns, att = att_name.split('|')
+                            try:
+                                ns = self.css_namespaces[ns]
+                            except KeyError:
+                                logger.warning(u"Undefined namespace prefix {}"
+                                               .format(ns).encode('utf-8'))
+                                continue
+                            att_name = etree.QName(ns, att)
                         strval += element.etree_element.get(att_name, att_def)
                     else:
                         logger.warning(u"Bad string-set: {}".format(
@@ -1092,6 +1110,15 @@ class Oven():
                     if len(att_args) > 1:
                         att_def = self.eval_string_value(element,
                                                          att_args[1])[0]
+                    if '|' in att_name:
+                        ns, att = att_name.split('|')
+                        try:
+                            ns = self.css_namespaces[ns]
+                        except KeyError:
+                            logger.warning(u"Undefined namespace prefix {}"
+                                           .format(ns).encode('utf-8'))
+                            continue
+                        att_name = etree.QName(ns, att)
                     att_val = element.etree_element.get(att_name, att_def)
                     actions.append(('string', att_val))
 

--- a/cnxeasybake/tests/html/attr_namespace.log
+++ b/cnxeasybake/tests/html/attr_namespace.log
@@ -1,0 +1,22 @@
+cnx-easybake DEBUG Passes: ['default']
+cnx-easybake DEBUG Rule (4): span#content 
+cnx-easybake DEBUG     default: content attr(ns|attr)
+cnx-easybake DEBUG IdentToken as string: ns
+cnx-easybake DEBUG LiteralToken as string: |
+cnx-easybake DEBUG IdentToken as string: attr
+cnx-easybake DEBUG Rule (8): span#string-set 
+cnx-easybake DEBUG     default: string-set test attr(ns|attr)
+cnx-easybake DEBUG IdentToken as string: ns
+cnx-easybake DEBUG LiteralToken as string: |
+cnx-easybake DEBUG IdentToken as string: attr
+cnx-easybake DEBUG Rule (12): span#string-set::after 
+cnx-easybake DEBUG     default: container span
+cnx-easybake DEBUG     default: content string(test)
+cnx-easybake DEBUG IdentToken as string: test
+cnx-easybake DEBUG Rule (17): span#nested 
+cnx-easybake DEBUG     default: content target-string(attr(ns|href), test)
+cnx-easybake DEBUG IdentToken as string: ns
+cnx-easybake DEBUG LiteralToken as string: |
+cnx-easybake DEBUG IdentToken as string: href
+cnx-easybake DEBUG IdentToken as string: test
+cnx-easybake DEBUG Recipe default length: 11

--- a/cnxeasybake/tests/html/attr_namespace_baked.html
+++ b/cnxeasybake/tests/html/attr_namespace_baked.html
@@ -1,0 +1,5 @@
+<body xmlns:ns="urn:ns">
+  <span id="content" ns:attr="First">First</span>
+  <span id="string-set" ns:attr="Second"><span>Second</span></span>
+  <span id="nested" ns:href="#string-set">Second</span>
+</body>

--- a/cnxeasybake/tests/html/attr_namespace_raw.html
+++ b/cnxeasybake/tests/html/attr_namespace_raw.html
@@ -1,0 +1,5 @@
+<body xmlns:ns="urn:ns">
+  <span id="content" ns:attr="First"/>
+  <span id="string-set" ns:attr="Second"/>
+  <span id="nested" ns:href="#string-set"/>
+</body>

--- a/cnxeasybake/tests/rulesets/attr_namespace.css
+++ b/cnxeasybake/tests/rulesets/attr_namespace.css
@@ -1,0 +1,19 @@
+/* Namespace prefix in the attr() function */
+@namespace ns "urn:ns";
+
+span#content {
+  content: attr(ns|attr);
+}
+
+span#string-set {
+  string-set: test attr(ns|attr);
+}
+
+span#string-set::after {
+  container: span;
+  content: string(test);
+}
+
+span#nested {
+  content: target-string(attr(ns|href), test);
+}


### PR DESCRIPTION
As per drafts.csswg.org/css-values-3/#attr-notation, `attr` should support namespace prefixes on attribute names.

Example CSS

```css
@namespace ns "urn:ns";

span#content {
  content: attr(ns|attr);
}

span#string-set {
  string-set: test attr(ns|attr);
}

span#string-set::after {
  container: span;
  content: string(test);
}

span#nested {
  content: target-string(attr(ns|href), test);
}
```

Example XHTML

```xhtml
<body xmlns:ns="urn:ns">
  <span id="content" ns:attr="First"/>
  <span id="string-set" ns:attr="Second"/>
  <span id="nested" ns:href="#string-set"/>
</body>
```

Output HTML

```xhtml
<body xmlns:ns="urn:ns">
  <span id="content" ns:attr="First">First</span>
  <span id="string-set" ns:attr="Second"><span>Second</span></span>
  <span id="nested" ns:href="#string-set">Second</span>
</body>
```

Without this patch the first three rules have no effect, and the last one crashes easybake.