### PR TITLE
pin the version of pyICU for mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = (
     'cssselect2',
     'tinycss2',
     'lxml',
-    'PyICU',
+    'PyICU==1.9.8',
     )
 
 tests_require = (

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ install_requires = (
     'cssselect2',
     'tinycss2',
     'lxml',
-    'PyICU==1.9.8',
+    'PyICU==1.9.8;platform_system=="Darwin"',  # FIXME link/symbol prob OSX
+    'PyICU',
     )
 
 tests_require = (


### PR DESCRIPTION
2.0.3 generates an Invalid Symbol error when loading the ICU library